### PR TITLE
Add collectionTypes to by-sierra lookup

### DIFF
--- a/lib/by_sierra_location_factory.js
+++ b/lib/by_sierra_location_factory.js
@@ -64,9 +64,14 @@ class BySierraLocationFactory extends FactoryBase {
 
       recapCodesforSierraDeliverableLocations = jsonldParseUtils.forcetoFlatArray(recapCodesforSierraDeliverableLocations)
 
+      // Note: This is about to change to .. collectionType?
+      // It it isn't set, default to 'Branch'
+      let collectionTypes = jsonldParseUtils.forcetoFlatArray(location['nypl:locationType'] || 'Branch')
+
       _returnedMap[code] = {
         code,
         label,
+        collectionTypes,
         recapLocation: thisLocationAsRecap,
         sierraDeliveryLocations
       }

--- a/test/by-sierra-location.test.js
+++ b/test/by-sierra-location.test.js
@@ -52,5 +52,12 @@ describe('by-sierra-location', function () {
         expect(location.recapLocation.eddRequestable).to.be.a('boolean')
       })
     })
+
+    it('has collectionTypes', function () {
+      Object.keys(this.bySierraLocation).forEach((sierraCode) => {
+        expect(this.bySierraLocation[sierraCode].collectionTypes).to.be.a('array')
+        expect(this.bySierraLocation[sierraCode].collectionTypes).to.not.be.empty
+      })
+    })
   })
 })


### PR DESCRIPTION
Adds `collectionTypes` (array of 'Branch', 'Research' strings) to elements of by-sierra-location lookup. This will allow the store-poster to use this mapper for quickly determining whether an item's holdingLocation implies the item is research, branch, or both.