### PR TITLE
Aadd P-type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For a comprehensive list of availability see the implementation of factories men
 
 * Locations (from [locations.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/locations.json) & [recapCustomerCodes.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/recapCustomerCodes.json))
 
+* Patron Types (from [patronTypes.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/patronTypes.json))
 ## Git Workflow
 
 When you _file_ a PR - it should include a version bump.  

--- a/lib/by_patron_type_factory.js
+++ b/lib/by_patron_type_factory.js
@@ -1,0 +1,24 @@
+const jsonldParseUtils = require('./jsonld-parse-utils')
+const FactoryBase = require('./factory_base')
+
+class ByPatronTypeFactory extends FactoryBase {
+
+  // returns a mapping with Sierra codes at its top-level
+  static createMapping () {
+    this.patronTypeJSON = this._getPatronTypeJsonLD()['@graph']
+    let result = {}
+
+    for (let patronType in this.patronTypeJSON) {
+      let accessibleDeliveryLocationTypes = jsonldParseUtils.forcetoFlatArray(this.patronTypeJSON[patronType]['nypl:deliveryLocationAccess'])
+
+      result[patronType] = {
+        'label': this.patronTypeJSON[patronType]['skos:prefLabel'],
+        'accessibleDeliveryLocationTypes': accessibleDeliveryLocationTypes
+      }
+    }
+
+    return result
+  }
+}
+
+module.exports = ByPatronTypeFactory

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -15,11 +15,11 @@ class FactoryBase {
     return this.recapCustomerCodes
   }
 
-  static _getPatronType () {
-    if (!this.patronTypes) {
-      this.patronTypes = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/patronTypes.json').getBody())
+  static _getPatronTypeJsonLD () {
+    if (!this.patronTypeJsonLD) {
+      this.patronTypeJsonLD = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/patronTypes.json').getBody())
     }
-    return this.patronTypes
+    return this.patronTypeJsonLD
   }
 }
 

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -14,6 +14,13 @@ class FactoryBase {
     }
     return this.recapCustomerCodes
   }
+
+  static _getPatronType () {
+    if (!this.patronTypes) {
+      this.patronTypes = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/patronTypes.json').getBody())
+    }
+    return this.patronTypes
+  }
 }
 
 module.exports = FactoryBase

--- a/nypl-core-objects.js
+++ b/nypl-core-objects.js
@@ -1,5 +1,6 @@
 const ByRecapCustomerCodeFactory = require('./lib/by_recap_customer_code_factory')
 const BySierraLocationFactory = require('./lib/by_sierra_location_factory')
+const ByPatronTypeFactory = require('./lib/by_patron_type_factory')
 
 module.exports = (maptype) => {
   switch (maptype) {
@@ -7,6 +8,8 @@ module.exports = (maptype) => {
       return ByRecapCustomerCodeFactory.createMapping()
     case 'by-sierra-location':
       return BySierraLocationFactory.createMapping()
+    case 'by-patron-type':
+      return ByPatronTypeFactory.createMapping()
     default:
       throw new Error('NYPL Core Objects: Unrecognized maptype: ' + maptype)
   }

--- a/test/by-patron-type.test.js
+++ b/test/by-patron-type.test.js
@@ -9,7 +9,7 @@ function takeThisPartyOffline () {
   FactoryBase._getPatronTypeJsonLD = mockedPatronTypeJSONLD
 }
 
-describe('by-sierra-location', function () {
+describe('by-patron-type', function () {
   before(function () {
     takeThisPartyOffline()
     this.byPatronType = require('../nypl-core-objects')('by-patron-type')

--- a/test/by-patron-type.test.js
+++ b/test/by-patron-type.test.js
@@ -1,0 +1,33 @@
+let expect = require('chai').expect
+const sinon = require('sinon')
+const fs = require('fs')
+const path = require('path')
+
+function takeThisPartyOffline () {
+  let FactoryBase = require('../lib/factory_base')
+  let mockedPatronTypeJSONLD = sinon.stub().returns(JSON.parse(fs.readFileSync(path.join(__dirname, './resources/patronTypes.json'))))
+  FactoryBase._getPatronTypeJsonLD = mockedPatronTypeJSONLD
+}
+
+describe('by-sierra-location', function () {
+  before(function () {
+    takeThisPartyOffline()
+    this.byPatronType = require('../nypl-core-objects')('by-patron-type')
+  })
+
+  it('exports a simpleObject', function (done) {
+    expect(this.byPatronType).to.not.equal(undefined)
+    expect(this.byPatronType).to.be.a('object')
+    done()
+  })
+
+  it('will have "label" & "accessibleDeliveryLocationTypes" properties for each key', function () {
+    expect(Object.keys(this.byPatronType)).to.not.be.empty
+    for (let key in this.byPatronType) {
+      let patronType = this.byPatronType[key]
+      expect(patronType['label']).to.be.a('string')
+      expect(patronType['accessibleDeliveryLocationTypes']).to.be.a('array')
+      expect(patronType['accessibleDeliveryLocationTypes']).to.not.be.empty
+    }
+  })
+})

--- a/test/by-sierra-location.test.js
+++ b/test/by-sierra-location.test.js
@@ -4,9 +4,11 @@ const fs = require('fs')
 const path = require('path')
 
 function takeThisPartyOffline () {
-  let BySierraLocationFactory = require('../lib/by_sierra_location_factory')
+  let FactoryBase = require('../lib/factory_base')
   let mockedSierra = sinon.stub().returns(JSON.parse(fs.readFileSync(path.join(__dirname, './resources/locations.json'))))
-  BySierraLocationFactory._getSierraJsonLD = mockedSierra
+  let mockedRecap = sinon.stub().returns(JSON.parse(fs.readFileSync(path.join(__dirname, './resources/recapCustomerCodes.json'))))
+  FactoryBase._getSierraJsonLD = mockedSierra
+  FactoryBase._getRecapJsonLD = mockedRecap
 }
 
 describe('by-sierra-location', function () {

--- a/test/resources/patronTypes.json
+++ b/test/resources/patronTypes.json
@@ -1,0 +1,294 @@
+{
+  "@context": {
+    "nypl": "http://data.nypl.org/nypl-core/",
+    "nyplOrg": "http://data.nypl.org/orgs/",
+    "ptype": "http://data.nypl.org/patronTypes/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "ptype:51",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "51",
+      "skos:prefLabel": "Teen 13-17 NY State"
+    },
+    {
+      "@id": "ptype:50",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "50",
+      "skos:prefLabel": "Teen 13-17 Metro"
+    },
+    {
+      "@id": "ptype:78",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "78",
+      "skos:prefLabel": "Short Term Scholar"
+    },
+    {
+      "@id": "ptype:31",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "31",
+      "skos:prefLabel": "Senior, 65+, NY State (3 Year)"
+    },
+    {
+      "@id": "ptype:30",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "30",
+      "skos:prefLabel": "Senior, 65+, Metro (3 Year)"
+    },
+    {
+      "@id": "ptype:73",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "73",
+      "skos:prefLabel": "Homebound Juv Only NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:72",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "72",
+      "skos:prefLabel": "Homebound NYC (3 Year)"
+    },
+    {
+      "@id": "ptype:70",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "70",
+      "skos:prefLabel": "Disabled Metro NY (3 Year)"
+    },
+    {
+      "@id": "ptype:100",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "100",
+      "skos:prefLabel": "INACTIVE PATRON"
+    },
+    {
+      "@id": "ptype:82",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "82",
+      "skos:prefLabel": "Scholar"
+    },
+    {
+      "@id": "ptype:83",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "83",
+      "skos:prefLabel": "Temporary (3 Day Research Only)"
+    },
+    {
+      "@id": "ptype:80",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "80",
+      "skos:prefLabel": "CUNY Graduate Center (9/30)"
+    },
+    {
+      "@id": "ptype:81",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "81",
+      "skos:prefLabel": "MaRLI (9/30)"
+    },
+    {
+      "@id": "ptype:86",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "86",
+      "skos:prefLabel": "Wertheim Scholar"
+    },
+    {
+      "@id": "ptype:87",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "87",
+      "skos:prefLabel": "Allen Scholar"
+    },
+    {
+      "@id": "ptype:84",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "84",
+      "skos:prefLabel": "Visitor (3 Month Limited Use)"
+    },
+    {
+      "@id": "ptype:85",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "85",
+      "skos:prefLabel": "ILL - Research"
+    },
+    {
+      "@id": "ptype:88",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Scholar",
+        "Research"
+      ],
+      "skos:notation": "88",
+      "skos:prefLabel": "Shoichi Noma Scholar"
+    },
+    {
+      "@id": "ptype:101",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "101",
+      "skos:prefLabel": "PENDING DISPUTE"
+    },
+    {
+      "@id": "ptype:106",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": [
+        "Research",
+        "Scholar"
+      ],
+      "skos:notation": "106",
+      "skos:prefLabel": "NYPL Department"
+    },
+    {
+      "@id": "ptype:60",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "60",
+      "skos:prefLabel": "Child 0-12 Juv Only Metro"
+    },
+    {
+      "@id": "ptype:61",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "61",
+      "skos:prefLabel": "Child 0-12 All Access Metro"
+    },
+    {
+      "@id": "ptype:62",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "62",
+      "skos:prefLabel": "Child 0-12 Juv Only NY State"
+    },
+    {
+      "@id": "ptype:63",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "63",
+      "skos:prefLabel": "Child 0-12 All Access NY State"
+    },
+    {
+      "@id": "ptype:1",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "1",
+      "skos:prefLabel": "Web Applicant (No Borrowing)"
+    },
+    {
+      "@id": "ptype:0",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "0",
+      "skos:prefLabel": "Undefined (Do Not Use)"
+    },
+    {
+      "@id": "ptype:3",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "3",
+      "skos:prefLabel": "SimplyE Non-Metro"
+    },
+    {
+      "@id": "ptype:149",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "149",
+      "skos:prefLabel": "MyLibraryNYC Educator Queens"
+    },
+    {
+      "@id": "ptype:116",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "116",
+      "skos:prefLabel": "NYPL Retiree, Non-NYS (3 Year)"
+    },
+    {
+      "@id": "ptype:91",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "91",
+      "skos:prefLabel": "(Non-MyLibraryNYC) NYC Educator"
+    },
+    {
+      "@id": "ptype:90",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "90",
+      "skos:prefLabel": "Organization (1 Year Only)"
+    },
+    {
+      "@id": "ptype:151",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "151",
+      "skos:prefLabel": "MyLibraryNYC Educator"
+    },
+    {
+      "@id": "ptype:150",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "150",
+      "skos:prefLabel": "MyLibNYC Child 0-12 All Access"
+    },
+    {
+      "@id": "ptype:153",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "153",
+      "skos:prefLabel": "MyLibraryNYC 13-17 Teen"
+    },
+    {
+      "@id": "ptype:152",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "152",
+      "skos:prefLabel": "MyLibNYC Child 0-12 JuvItem Only"
+    },
+    {
+      "@id": "ptype:2",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "2",
+      "skos:prefLabel": "SimplyE Metro"
+    },
+    {
+      "@id": "ptype:11",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "11",
+      "skos:prefLabel": "Adult 18-64 NY State (3 Year)"
+    },
+    {
+      "@id": "ptype:10",
+      "@type": "nypl:PatronType",
+      "nypl:deliveryLocationAccess": "Research",
+      "skos:notation": "10",
+      "skos:prefLabel": "Adult 18-64 Metro (3 Year)"
+    }
+  ]
+}


### PR DESCRIPTION
Hey @nonword.

This adds a mapping of Patron type from https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/patronTypes.json.

The basic shape looks like:

```
{
  'p-type':   {'label': 'the name', 'accessibleDeliveryLocationTypes': [An Array]},
  'p-type2': {'label': 'its name', 'accessibleDeliveryLocationTypes': [An Array]}
}
```