### PR TITLE
Add generic baseline mapping for types not explicitly parsed

### DIFF
--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -52,7 +52,12 @@ class FactoryBase {
 
     return this.doc.reduce((result, item) => {
       // Pick a sensible lookup key:
-      let mappingKey = item['skos:notation'] || item['@id']
+      let mappingKey = null
+      if (item['@id']) {
+        mappingKey = item['@id'].split(':').pop()
+      } else {
+        mappingKey = item['skos:notation']
+      }
 
       // Build a hash of fields one might want mapped:
       let mappedFields = {}

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -24,17 +24,21 @@ class FactoryBase {
   }
 
   static _getJsonLD (filename) {
-    if (!this._jsonld_cache) this._jsonld_cache = {}
+    if (this._jsonld_cache && this._jsonld_cache[filename]) {
+      return this._jsonld_cache[filename]
+    } else {
+      if (!this._jsonld_cache) this._jsonld_cache = {}
 
-    var content = null
-    try {
-      content = request('GET', `https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/${filename}.json`).getBody()
-    } catch (e) {
-      throw new FactoryBase.MappingNameError(`Unrecognized mapping file: ${filename}`)
+      var content = null
+      try {
+        content = request('GET', `https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/${filename}.json`).getBody()
+      } catch (e) {
+        throw new FactoryBase.MappingNameError(`Unrecognized mapping file: ${filename}`)
+      }
+
+      this._jsonld_cache[filename] = JSON.parse(content)
+      return this._jsonld_cache[filename]
     }
-    if (!this._jsonld_cache[filename]) this._jsonld_cache[filename] = JSON.parse(content)
-
-    return this._jsonld_cache[filename]
   }
 
   // returns a base-line hash mapping code/id to a minimum field set (just labels for now)

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -1,4 +1,5 @@
 const request = require('sync-request')
+const jsonldParseUtils = require('./jsonld-parse-utils')
 
 class FactoryBase {
   static _getSierraJsonLD () {
@@ -21,6 +22,51 @@ class FactoryBase {
     }
     return this.patronTypeJsonLD
   }
+
+  static _getJsonLD (filename) {
+    if (!this._jsonld_cache) this._jsonld_cache = {}
+
+    var content = null
+    try {
+      content = request('GET', `https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/${filename}.json`).getBody()
+    } catch (e) {
+      throw new FactoryBase.MappingNameError(`Unrecognized mapping file: ${filename}`)
+    }
+    if (!this._jsonld_cache[filename]) this._jsonld_cache[filename] = JSON.parse(content)
+
+    return this._jsonld_cache[filename]
+  }
+
+  // returns a base-line hash mapping code/id to a minimum field set (just labels for now)
+  static createMapping (key) {
+    // Convert from hyphen "by-..." phrase to the known github file naming convention for mapping files
+    // e.g. from 'by-catalog-item-types' to 'catalogItemTypes'
+    let filename = jsonldParseUtils.hyphenToCamelCase(key.replace(/^by-/, ''))
+
+    // Try to tech remote file:
+    this.doc = this._getJsonLD(filename)['@graph']
+
+    return this.doc.reduce((result, item) => {
+      // Pick a sensible lookup key:
+      let mappingKey = item['skos:notation'] || item['@id']
+
+      // Build a hash of fields one might want mapped:
+      let mappedFields = {}
+      if (item['@id']) mappedFields.id = item['@id']
+      if (item['skos:notation']) mappedFields.code = item['skos:notation']
+      if (item['skos:prefLabel']) mappedFields.label = item['skos:prefLabel']
+
+      result[mappingKey] = mappedFields
+      return result
+    }, {})
+  }
 }
+
+// Custom error class for reporting unrecognized mapping filenames
+FactoryBase.MappingNameError = function (message) {
+  this.name = 'MappingNameError'
+  this.message = (message || '')
+}
+FactoryBase.MappingNameError.prototype = Error.prototype
 
 module.exports = FactoryBase

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -64,6 +64,7 @@ class FactoryBase {
       if (item['@id']) mappedFields.id = item['@id']
       if (item['skos:notation']) mappedFields.code = item['skos:notation']
       if (item['skos:prefLabel']) mappedFields.label = item['skos:prefLabel']
+      if (item['nypl:requestable']) mappedFields.requestable = jsonldParseUtils._conditional_boolean(item['nypl:requestable'])
 
       result[mappingKey] = mappedFields
       return result

--- a/lib/jsonld-parse-utils.js
+++ b/lib/jsonld-parse-utils.js
@@ -11,3 +11,6 @@ module.exports._conditional_boolean = (entity) => {
   }
   return (entity['@type'] === 'XSD:boolean') ? Boolean(entity['@value']) : entity['@value']
 }
+
+// Takes a phrase of form 'one-two-three' and converts it to camel (i.e. 'oneTwoThree')
+module.exports.hyphenToCamelCase = (phrase) => phrase.split('-').map((word, index) => index === 0 ? word : word[0].toUpperCase() + word.substring(1)).join('')

--- a/nypl-core-objects.js
+++ b/nypl-core-objects.js
@@ -1,6 +1,7 @@
 const ByRecapCustomerCodeFactory = require('./lib/by_recap_customer_code_factory')
 const BySierraLocationFactory = require('./lib/by_sierra_location_factory')
 const ByPatronTypeFactory = require('./lib/by_patron_type_factory')
+const FactoryBase = require('./lib/factory_base')
 
 module.exports = (maptype) => {
   switch (maptype) {
@@ -11,6 +12,8 @@ module.exports = (maptype) => {
     case 'by-patron-type':
       return ByPatronTypeFactory.createMapping()
     default:
-      throw new Error('NYPL Core Objects: Unrecognized maptype: ' + maptype)
+      // Attempt to create a basic map based on maptype:
+      // Will throw a MappingNameError if unrecognized
+      return FactoryBase.createMapping(maptype)
   }
 }

--- a/test/generic-mapping.test.js
+++ b/test/generic-mapping.test.js
@@ -1,0 +1,46 @@
+let expect = require('chai').expect
+const sinon = require('sinon')
+const fs = require('fs')
+const path = require('path')
+
+function takeThisPartyOffline () {
+  let FactoryBase = require('../lib/factory_base')
+  let mockedSierra = sinon.stub().returns(JSON.parse(fs.readFileSync(path.join(__dirname, './resources/locations.json'))))
+  let mockedRecap = sinon.stub().returns(JSON.parse(fs.readFileSync(path.join(__dirname, './resources/recapCustomerCodes.json'))))
+  FactoryBase._getSierraJsonLD = mockedSierra
+  FactoryBase._getRecapJsonLD = mockedRecap
+}
+
+describe('generic-mapping', function () {
+  before(function () {
+    // takeThisPartyOffline()
+    takeThisPartyOffline
+    this.catalogItemTypeMapping = require('../nypl-core-objects')('by-catalog-item-types')
+  })
+
+  it('by-foo-bar triggers MappingNameError error', function (done) {
+    let attemptBadMapping = () => require('../nypl-core-objects')('by-foo-bar')
+    expect(attemptBadMapping).to.throw('MappingNameError')
+    done()
+  })
+
+  it('known mapping names exports a simpleObject', function () {
+    return Promise.all(['by-catalog-item-types', 'by-datasources', 'by-icode2'].map((phrase) => {
+      let mapping = require('../nypl-core-objects')(phrase)
+      expect(mapping).to.not.equal(undefined)
+      expect(mapping).to.be.a('object')
+    }))
+  })
+
+  it('known mapping names have a "label", "id" property for each key', function () {
+    return Promise.all(['by-catalog-item-types', 'by-datasources', 'by-icode2'].map((phrase) => {
+      let mapping = require('../nypl-core-objects')(phrase)
+      expect(Object.keys(mapping)).to.not.be.empty
+      for (let key in mapping) {
+        let entity = mapping[key]
+        expect(entity['label']).to.be.a('string')
+        expect(entity['id']).to.be.a('string')
+      }
+    }))
+  })
+})

--- a/test/resources/catalogItemTypes.json
+++ b/test/resources/catalogItemTypes.json
@@ -1,0 +1,1272 @@
+{
+  "@context": {
+    "nypl": "http://data.nypl.org/nypl-core/",
+    "nyplCatalogItemTypes": "http://data.nypl.org/catalogItemTypes/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "nyplCatalogItemTypes:28",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "28",
+      "skos:note": "P.M.",
+      "skos:prefLabel": "printing master negative"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:253",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "253",
+      "skos:note": "DOE Only",
+      "skos:prefLabel": "Teacher Set Playaway"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:252",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "252",
+      "skos:note": "DOE Only",
+      "skos:prefLabel": "Teacher Set (DOE EDUCATOR ONLY)"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:41",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "41",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "internet archive, non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:43",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "43",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "internet archive, serial"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:42",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "42",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "internet archive, book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:8",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "8",
+      "skos:prefLabel": "manuscript music"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:9",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "9",
+      "skos:prefLabel": "map"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:4",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "4",
+      "skos:note": "Periodicals etc.",
+      "skos:prefLabel": "serial, loose"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:5",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "5",
+      "skos:note": "Periodicals etc.",
+      "skos:prefLabel": "serial, loose, 1 hour"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:6",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "6",
+      "skos:prefLabel": "microfilm service copy"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:7",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "7",
+      "skos:prefLabel": "printed music, non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:0",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "0",
+      "skos:note": "Do Not Use",
+      "skos:prefLabel": "default"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:1",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "1",
+      "skos:note": "General Materials",
+      "skos:prefLabel": "non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:2",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "2",
+      "skos:note": "General Bound Book",
+      "skos:prefLabel": "book non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:3",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "3",
+      "skos:note": "Periodicals etc.",
+      "skos:prefLabel": "serial"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:29",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "29",
+      "skos:prefLabel": "bundled materials (vols.)"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:217",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "217",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J Blu-ray"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:27",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "27",
+      "skos:note": "A.O. (archival original)",
+      "skos:prefLabel": "preservation master negative"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:26",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "26",
+      "skos:prefLabel": "microfiche"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:25",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "25",
+      "skos:prefLabel": "atlas"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:24",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "24",
+      "skos:note": "Preservation Copy",
+      "skos:prefLabel": "archival video recording"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:23",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "23",
+      "skos:note": "Preservation Copy",
+      "skos:prefLabel": "archival sound recording"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:22",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "22",
+      "skos:prefLabel": "clipping files"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:21",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "21",
+      "skos:note": "Print",
+      "skos:prefLabel": "archival material"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:20",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "20",
+      "skos:prefLabel": "manuscript"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:52",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "52",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "i-archive/google monograph"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:53",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "53",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "i-archive/google serial"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:50",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "50",
+      "skos:note": "temporary item - ReCAP request",
+      "skos:prefLabel": "offsite requesting (ncip)"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:51",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "51",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "i-archive/google non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:57",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "57",
+      "skos:note": "Leaves SASB",
+      "skos:prefLabel": "printed music limited circ MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:55",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "55",
+      "skos:note": "Leaves SASB",
+      "skos:prefLabel": "book, limited circ, MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:118",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "118",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Recorded book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:119",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "119",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Software"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:110",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "110",
+      "skos:note": "Adult",
+      "skos:prefLabel": "VHS"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:111",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "111",
+      "skos:note": "Adult",
+      "skos:prefLabel": "DVD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:112",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "112",
+      "skos:note": "Adult",
+      "skos:prefLabel": "DVD express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:113",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "113",
+      "skos:note": "Adult",
+      "skos:prefLabel": "VCD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:114",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "114",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Compact disc"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:115",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "115",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Cd express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:116",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "116",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Audiocassette"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:117",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "117",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Book, circ, 2-Week, New"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:38",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "38",
+      "skos:prefLabel": "art and artifacts"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:34",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "34",
+      "skos:prefLabel": "micro-opaque"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:35",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "35",
+      "skos:prefLabel": "cd-rom, dvd-rom"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:36",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "36",
+      "skos:prefLabel": "www based"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:37",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "37",
+      "skos:note": "A.O. ???",
+      "skos:prefLabel": "master recording"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:30",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "30",
+      "skos:prefLabel": "loose newspaper"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:31",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "31",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "google project, non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:32",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "32",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "google project, book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:33",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "33",
+      "skos:note": "Public Domain",
+      "skos:prefLabel": "google project, serial"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:109",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "109",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Lpa song index score"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:108",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "108",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Lpa score"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:103",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "103",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Book, express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:102",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "102",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Book, paperback"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:101",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "101",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Book, circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:107",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "107",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Periodical, circ, serial"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:106",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "106",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Center for reading/writing"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:105",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "105",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Pamphlet"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:104",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "104",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Reference non-circ Book,PER,etc."
+    },
+    {
+      "@id": "nyplCatalogItemTypes:201",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "201",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:202",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "202",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J recorded book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:203",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "203",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J compact disc"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:204",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "204",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J cd-rom"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:205",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "205",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J audiocassette"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:206",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "206",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J DVD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:207",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "207",
+      "skos:note": "Juvenile, ON-THE-FLY",
+      "skos:prefLabel": "J fast add item"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:208",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "208",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J game express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:209",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "209",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J mixed media set"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:134",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "134",
+      "skos:note": "LPA Only",
+      "skos:prefLabel": "RFVC - VHS"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:135",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "135",
+      "skos:note": "LPA Only",
+      "skos:prefLabel": "RFVC - DVD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:132",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "132",
+      "skos:note": "LPA Only",
+      "skos:prefLabel": "RFVC - FILM"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:133",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "133",
+      "skos:note": "LPA Only",
+      "skos:prefLabel": "RFVC - FILM PRESERVATION"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:130",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "130",
+      "skos:prefLabel": "Equipment"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:131",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "131",
+      "skos:note": "On-The-Fly",
+      "skos:prefLabel": "Adult fast add item"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:121",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "121",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Mixed media set"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:120",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "120",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Picture"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:123",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "123",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Game express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:213",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "213",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J reference"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:212",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "212",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J periodical"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:211",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "211",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J paperback"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:122",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "122",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Cd-rom"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:125",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "125",
+      "skos:prefLabel": "E-nypl audio book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:124",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "124",
+      "skos:prefLabel": "E-nypl book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:127",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "127",
+      "skos:prefLabel": "E-nypl video"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:126",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "126",
+      "skos:prefLabel": "E-nypl music"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:129",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "129",
+      "skos:prefLabel": "Borrowed ILL"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:128",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "128",
+      "skos:prefLabel": "Wireless laptop"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:219",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "219",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J ELL book at AG IN MH SE"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:218",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "218",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J Blu-ray express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:216",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "216",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J DVD express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:215",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "215",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J videocassette"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:214",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "214",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J software"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:210",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "210",
+      "skos:note": "Juvenile",
+      "skos:prefLabel": "J long playing record"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:16",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "16",
+      "skos:prefLabel": "computer file"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:17",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "17",
+      "skos:prefLabel": "kit"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:14",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "14",
+      "skos:note": "Service Copy",
+      "skos:prefLabel": "moving image"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:15",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "15",
+      "skos:prefLabel": "flat graphic"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:12",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "12",
+      "skos:note": "Service Copy",
+      "skos:prefLabel": "musical sound recording"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:13",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "13",
+      "skos:note": "Service Copy",
+      "skos:prefLabel": "spoken sound recording"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:10",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "10",
+      "skos:prefLabel": "map, manuscript"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:11",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "11",
+      "skos:note": "Service Copy",
+      "skos:prefLabel": "videorecording, non-circ"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:18",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "18",
+      "skos:prefLabel": "mixed medium collection"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:19",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "19",
+      "skos:prefLabel": "3-D object"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:150",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "150",
+      "skos:prefLabel": "Clear WiFi Access Point"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:220",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "220",
+      "skos:prefLabel": "J pre-k book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:239",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "239",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA periodical"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:238",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "238",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA paperback"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:231",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "231",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:230",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "230",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA DVD express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:233",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "233",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA CD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:232",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "232",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA recorded book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:235",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "235",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA DVD"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:234",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "234",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA CD express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:237",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "237",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA pamphlet"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:236",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "236",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA game express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:61",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "61",
+      "skos:prefLabel": "pamphlet volumes, bound with"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:60",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "60",
+      "skos:prefLabel": "pamphlets, singles, 1-50 pages"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:67",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "67",
+      "skos:note": "Conservation Candidate",
+      "skos:prefLabel": "printed music, good, non-MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:66",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "66",
+      "skos:note": "Conservation Candidate",
+      "skos:prefLabel": "book, poor condition, non-MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:65",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "65",
+      "skos:note": "Conservation Candidate",
+      "skos:prefLabel": "book, good condition, non-MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:68",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "68",
+      "skos:note": "Conservation Candidate",
+      "skos:prefLabel": "printed music, poor, non-MaRLI"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:144",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "144",
+      "skos:note": "LPA Only",
+      "skos:prefLabel": "Lpa orchestra collection"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:143",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "143",
+      "skos:prefLabel": "ELL book, iZone at AG,IN,MH,SE"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:142",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "142",
+      "skos:prefLabel": "RFVC - LPA Blu-ray"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:141",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "141",
+      "skos:prefLabel": "Blu-ray express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:140",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "140",
+      "skos:prefLabel": "Blu-ray"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:138",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "138",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Leased book, 3-week"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:139",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "139",
+      "skos:prefLabel": "Chrome book"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:240",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "240",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA Blu-ray"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:241",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "241",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA Blu-ray express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:242",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "242",
+      "skos:note": "Young Adult",
+      "skos:prefLabel": "YA ELL book at AG IN MH SE"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:136",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "136",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Leased book 2-Week, New"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:137",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Branch",
+      "skos:notation": "137",
+      "skos:note": "Adult",
+      "skos:prefLabel": "Leased book, express"
+    },
+    {
+      "@id": "nyplCatalogItemTypes:79",
+      "@type": "nypl:CatalogItemType",
+      "nypl:locationType": "Research",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "79",
+      "skos:prefLabel": "Interlibrary Loan - Research"
+    }
+  ]
+}

--- a/test/resources/datasources.json
+++ b/test/resources/datasources.json
@@ -1,0 +1,39 @@
+{
+  "@context": {
+    "nyplOrg": "http://data.nypl.org/orgs/",
+    "resourceType": "http://id.loc.gov/vocabulary/resourceTypes",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "data:10000",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "Shadowcat"
+    },
+    {
+      "@id": "data:10001",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "Archives Portal"
+    },
+    {
+      "@id": "data:10002",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "MMS"
+    },
+    {
+      "@id": "data:10003",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "TMS"
+    },
+    {
+      "@id": "data:10004",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "Sierra"
+    },
+    {
+      "@id": "data:10005",
+      "@type": "resourceType:dat",
+      "skos:prefLabel": "Recap"
+    }
+  ]
+}

--- a/test/resources/icode2.json
+++ b/test/resources/icode2.json
@@ -1,0 +1,91 @@
+{
+  "@context": {
+    "icode2": "http://data.nypl.org/icode2/",
+    "nypl": "http://data.nypl.org/nypl-core/",
+    "nyplOrg": "http://data.nypl.org/orgs/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "icode2:w",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "w",
+      "skos:prefLabel": "WITHDRAWN"
+    },
+    {
+      "@id": "icode2:m",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "m",
+      "skos:prefLabel": "M2 MOD"
+    },
+    {
+      "@id": "icode2:s",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "s",
+      "skos:prefLabel": "SUPPRESS"
+    },
+    {
+      "@id": "icode2:p",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "p",
+      "skos:prefLabel": "ARCHIVAL SUPPRESS"
+    },
+    {
+      "@id": "icode2:d",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "skos:notation": "d",
+      "skos:prefLabel": "CLOSED BRANCH"
+    },
+    {
+      "@id": "icode2:n",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "n",
+      "skos:prefLabel": "ANALYSIS"
+    },
+    {
+      "@id": "icode2:o",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "o",
+      "skos:prefLabel": "TSD TO MILSTEIN 2"
+    },
+    {
+      "@id": "icode2:-",
+      "@type": "nypl:Icode2",
+      "nypl:suppressed": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "-",
+      "skos:note": "this is the only one that is requestable and is not suppressed",
+      "skos:prefLabel": "---"
+    }
+  ]
+}


### PR DESCRIPTION
This PR proposes an amendment to the base factory class to allow us to use mappings that exist in nypl-core for which *we do not yet have dedicated parsing code*. This serves cases where we really only want to map `@id` or `skos:notation` to `skos:prefLabel`. 

For example, one common serialization task requires mapping catalogItemType code to its label. There may be special things we want to map to catalogItemTypes in the future, but for now we only want to map id/code to label. Rather than write a special parsing handler for catalogItemTypes, this PR proposes a generic baseline parser for json-ld mapping documents that haven't been explicitly mapped. This serves the catalogItemTypes case as well as similarly simple mappings I anticipate needing like datasources, organizations, etc.

Example usage:

```js
> require('./nypl-core-objects.js')('by-catalog-item-types')
{ '0': { id: 'nyplCatalogItemTypes:0', code: '0', label: 'default' },
  '1': { id: 'nyplCatalogItemTypes:1', code: '1', label: 'non-circ' },
  '2': 
   { id: 'nyplCatalogItemTypes:2',
     code: '2',
     label: 'book non-circ' },
  '3': { id: 'nyplCatalogItemTypes:3', code: '3', label: 'serial' },
  ...
```

This may be a little out there. Let's talk about whether/not this is reckless/complicating