### PR TITLE
Add delivery location type to each sierra-delivery-location

### DIFF
--- a/lib/by_recap_customer_code_factory.js
+++ b/lib/by_recap_customer_code_factory.js
@@ -20,7 +20,11 @@ class ByRecapCustomerCodeFactory extends FactoryBase {
         })
 
         sierraDeliveryLocations = sierraDeliveryLocations.map((sierraLocation) => {
-          return {code: sierraLocation['skos:notation'], label: sierraLocation['skos:prefLabel']}
+          return {
+            code: sierraLocation['skos:notation'],
+            label: sierraLocation['skos:prefLabel'],
+            deliveryLocationTypes: jsonldParseUtils.forcetoFlatArray(sierraLocation['nypl:deliveryLocationType'])
+          }
         })
       }
 

--- a/test/by-recap-customer-codes.test.js
+++ b/test/by-recap-customer-codes.test.js
@@ -62,6 +62,7 @@ describe('by-recap-customer-codes', function () {
     allSierraDeliverLocations.forEach((deliveryLocation) => {
       expect(deliveryLocation['code']).to.not.be.a('undefined')
       expect(deliveryLocation['label']).to.not.be.a('undefined')
+      expect(deliveryLocation['deliveryLocationTypes']).to.be.a('array')
     })
   })
 })

--- a/test/resources/locations.json
+++ b/test/resources/locations.json
@@ -16,43 +16,43 @@
       "nypl:actualLocation": "OFFSITE - TSD - Request in Advance",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
           "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:sc"
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:slr"
+        },
+        {
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:sc"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:myr"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mal"
         }
       ],
       "nypl:owner": {
@@ -72,6 +72,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0t",
       "skos:prefLabel": "Castle Hill Children's Fairy Tale"
     },
@@ -82,6 +83,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bryr",
       "skos:prefLabel": "George Bruce Young Adult Reference"
     },
@@ -92,18 +94,20 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cs",
       "skos:prefLabel": "Columbus"
     },
     {
-      "@id": "nyplLocation:cp",
+      "@id": "nyplLocation:ctj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:ct"
       },
-      "nypl:actualLocation": "Clason's Point",
-      "skos:notation": "cp",
-      "skos:prefLabel": "Clason's Point"
+      "nypl:actualLocation": "Castle Hill Children's Young Reader",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ctj0y",
+      "skos:prefLabel": "Castle Hill Children's Young Reader"
     },
     {
       "@id": "nyplLocation:qc2ma",
@@ -114,7 +118,22 @@
       "nypl:actualLocation": "OFFSITE - TSD - Request in Advance",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:myr"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:slr"
         },
         {
           "@id": "nyplLocation:mab"
@@ -126,31 +145,16 @@
           "@id": "nyplLocation:sc"
         },
         {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
           "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:slr"
+          "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:myr"
+          "@id": "nyplLocation:malc"
         }
       ],
       "nypl:owner": {
@@ -170,6 +174,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0a",
       "skos:prefLabel": "Castle Hill Children's Easy Book"
     },
@@ -180,6 +185,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ci",
       "skos:prefLabel": "City Island"
     },
@@ -190,6 +196,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0f",
       "skos:prefLabel": "Castle Hill Children's Fiction"
     },
@@ -210,6 +217,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0i",
       "skos:prefLabel": "Castle Hill Children's Picture Book"
     },
@@ -220,18 +228,20 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0h",
       "skos:prefLabel": "Castle Hill Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:tgzzz",
+      "@id": "nyplLocation:ctj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
+        "@id": "nyplLocation:ct"
       },
-      "nypl:actualLocation": "Throg's Neck (error code)",
-      "skos:notation": "tgzzz",
-      "skos:prefLabel": "Throg's Neck (error code)"
+      "nypl:actualLocation": "Castle Hill Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ctj0n",
+      "skos:prefLabel": "Castle Hill Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:ctj0l",
@@ -240,6 +250,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0l",
       "skos:prefLabel": "Castle Hill Children's World Languages"
     },
@@ -338,7 +349,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "maii2",
       "skos:prefLabel": "SASB - Periodicals and Microforms Rm 100"
@@ -362,19 +373,6 @@
       },
       "skos:notation": "maii3",
       "skos:prefLabel": "SASB - Periodicals and Microforms Rm 100"
-    },
-    {
-      "@id": "nyplLocation:Mar-62",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:Ma"
-      },
-      "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1108"
-      },
-      "skos:notation": "Mar-62",
-      "skos:prefLabel": "SASB - Rare Book Collection Rm 328"
     },
     {
       "@id": "nyplLocation:maii1",
@@ -417,14 +415,15 @@
       "skos:prefLabel": "Yorkville YA Reference"
     },
     {
-      "@id": "nyplLocation:ctj0y",
+      "@id": "nyplLocation:cp",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ct"
+        "@id": "nyplLocation:cp"
       },
-      "nypl:actualLocation": "Castle Hill Children's Young Reader",
-      "skos:notation": "ctj0y",
-      "skos:prefLabel": "Castle Hill Children's Young Reader"
+      "nypl:actualLocation": "Clason's Point",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cp",
+      "skos:prefLabel": "Clason's Point"
     },
     {
       "@id": "nyplLocation:mag98",
@@ -467,6 +466,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj01",
       "skos:prefLabel": "Castle Hill Children's Reference"
     },
@@ -567,6 +567,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj",
       "skos:prefLabel": "George Bruce Children"
     },
@@ -618,22 +619,19 @@
       },
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:maf"
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
           "@id": "nyplLocation:mab"
         },
         {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mag"
@@ -645,7 +643,10 @@
           "@id": "nyplLocation:malw"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mala"
         }
       ],
       "nypl:owner": {
@@ -653,7 +654,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "maf92",
       "skos:prefLabel": "SASB M2 - Dorot Jewish Division - Room 111"
@@ -665,6 +666,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gczzz",
       "skos:prefLabel": "Grand Central (error code)"
     },
@@ -675,6 +677,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ch",
       "skos:prefLabel": "Chatham Square"
     },
@@ -687,16 +690,6 @@
       "nypl:actualLocation": "Yorkville YA Fiction",
       "skos:notation": "yvy0f",
       "skos:prefLabel": "Yorkville YA Fiction"
-    },
-    {
-      "@id": "nyplLocation:fea01",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
-      },
-      "nypl:actualLocation": "58th Street Reference",
-      "skos:notation": "fea01",
-      "skos:prefLabel": "58th Street Reference"
     },
     {
       "@id": "nyplLocation:lmzzz",
@@ -745,6 +738,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbyr",
       "skos:prefLabel": "High Bridge Young Adult Reference"
     },
@@ -755,6 +749,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cl",
       "skos:prefLabel": "Morningside Heights"
     },
@@ -775,7 +770,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating Young Adult Recorded Media",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -868,6 +863,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ft",
       "skos:prefLabel": "53rd Street Branch"
     },
@@ -908,6 +904,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ca",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral"
     },
@@ -922,14 +919,14 @@
       "skos:prefLabel": "St. Agnes YA Reference"
     },
     {
-      "@id": "nyplLocation:ctj0n",
+      "@id": "nyplLocation:tgzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ct"
+        "@id": "nyplLocation:tg"
       },
-      "nypl:actualLocation": "Castle Hill Children's Non-Fiction",
-      "skos:notation": "ctj0n",
-      "skos:prefLabel": "Castle Hill Children's Non-Fiction"
+      "nypl:actualLocation": "Throg's Neck (error code)",
+      "skos:notation": "tgzzz",
+      "skos:prefLabel": "Throg's Neck (error code)"
     },
     {
       "@id": "nyplLocation:feyr",
@@ -938,6 +935,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "feyr",
       "skos:prefLabel": "58th Street Young Adult Reference"
     },
@@ -1087,6 +1085,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyyr",
       "skos:prefLabel": "Spuyten Duyvil Young Adult Reference"
     },
@@ -1161,16 +1160,6 @@
       "skos:prefLabel": "Andrew Heiskell YA Fiction"
     },
     {
-      "@id": "nyplLocation:ewj0a",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ew"
-      },
-      "nypl:actualLocation": "Edenwald Children's Easy Book",
-      "skos:notation": "ewj0a",
-      "skos:prefLabel": "Edenwald Children's Easy Book"
-    },
-    {
       "@id": "nyplLocation:mny0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -1236,10 +1225,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Music - Reference",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1123"
       },
@@ -1267,6 +1256,11 @@
         "@id": "nyplLocation:xf"
       },
       "nypl:actualLocation": "Inter-Library Loan",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:xfill"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NE"
       },
@@ -1280,6 +1274,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj01",
       "skos:prefLabel": "Edenwald Children's Reference"
     },
@@ -1364,6 +1359,17 @@
       "skos:prefLabel": "Macomb's Bridge YA Non-Fiction"
     },
     {
+      "@id": "nyplLocation:gcj0i",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:gc"
+      },
+      "nypl:actualLocation": "Grand Central Children's Picture Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "gcj0i",
+      "skos:prefLabel": "Grand Central Children's Picture Book"
+    },
+    {
       "@id": "nyplLocation:mby0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -1400,6 +1406,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0f",
       "skos:prefLabel": "Edenwald Children's Fiction"
     },
@@ -1414,17 +1421,15 @@
       "skos:prefLabel": "Jerome Park YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:mma2f",
+      "@id": "nyplLocation:ewj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mm"
+        "@id": "nyplLocation:ew"
       },
-      "nypl:actualLocation": "Mid-Manhattan Fiction Second Floor",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1500"
-      },
-      "skos:notation": "mma2f",
-      "skos:prefLabel": "Mid-Manhattan Fiction Second Floor"
+      "nypl:actualLocation": "Edenwald Children's Easy Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ewj0a",
+      "skos:prefLabel": "Edenwald Children's Easy Book"
     },
     {
       "@id": "nyplLocation:ewj0l",
@@ -1433,6 +1438,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0l",
       "skos:prefLabel": "Edenwald Children's World Languages"
     },
@@ -1463,6 +1469,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0h",
       "skos:prefLabel": "Edenwald Children's Holiday Book"
     },
@@ -1473,6 +1480,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0i",
       "skos:prefLabel": "Edenwald Children's Picture Book"
     },
@@ -1483,6 +1491,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0t",
       "skos:prefLabel": "Edenwald Children's Fairy Tale"
     },
@@ -1493,6 +1502,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0v",
       "skos:prefLabel": "Edenwald Children's Non-Print Media"
     },
@@ -1526,6 +1536,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0y",
       "skos:prefLabel": "Edenwald Children's Young Reader"
     },
@@ -1540,14 +1551,14 @@
       "skos:prefLabel": "Yorkville Children's Reference"
     },
     {
-      "@id": "nyplLocation:hua0f",
+      "@id": "nyplLocation:mea0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hu"
+        "@id": "nyplLocation:me"
       },
-      "nypl:actualLocation": "115th Street Fiction",
-      "skos:notation": "hua0f",
-      "skos:prefLabel": "115th Street Fiction"
+      "nypl:actualLocation": "Melrose Non-Print Media",
+      "skos:notation": "mea0v",
+      "skos:prefLabel": "Melrose Non-Print Media"
     },
     {
       "@id": "nyplLocation:hua0l",
@@ -1576,10 +1587,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Recorded Sound - Reference",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1124"
       },
@@ -1617,6 +1628,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdar",
       "skos:prefLabel": "125th Street Adult Reference"
     },
@@ -1657,6 +1669,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciar",
       "skos:prefLabel": "City Island Adult Reference"
     },
@@ -1747,6 +1760,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eajr",
       "skos:prefLabel": "Eastchester Children's Reference"
     },
@@ -1769,6 +1783,17 @@
       "nypl:actualLocation": "Yorkville Children's Holiday Book",
       "skos:notation": "yvj0h",
       "skos:prefLabel": "Yorkville Children's Holiday Book"
+    },
+    {
+      "@id": "nyplLocation:cpj0l",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:cp"
+      },
+      "nypl:actualLocation": "Clason's Point Children's World Languages",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cpj0l",
+      "skos:prefLabel": "Clason's Point Children's World Languages"
     },
     {
       "@id": "nyplLocation:mbar",
@@ -1797,6 +1822,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha",
       "skos:prefLabel": "Chatham Square Adult"
     },
@@ -1827,6 +1853,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj",
       "skos:prefLabel": "Chatham Square Children"
     },
@@ -1867,6 +1894,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy",
       "skos:prefLabel": "Chatham Square Young Adult"
     },
@@ -1897,6 +1925,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj",
       "skos:prefLabel": "Epiphany Children"
     },
@@ -1917,6 +1946,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa",
       "skos:prefLabel": "Epiphany Adult"
     },
@@ -1947,6 +1977,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy",
       "skos:prefLabel": "Grand Concourse Young Adult"
     },
@@ -1957,6 +1988,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epy",
       "skos:prefLabel": "Epiphany Young Adult"
     },
@@ -1967,6 +1999,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bejr",
       "skos:prefLabel": "Belmont Children's Reference"
     },
@@ -1977,6 +2010,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda",
       "skos:prefLabel": "Grand Concourse Adult"
     },
@@ -1987,6 +2021,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa01",
       "skos:prefLabel": "Columbus Reference"
     },
@@ -2007,6 +2042,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa03",
       "skos:prefLabel": "Columbus Closed Shelf Reference"
     },
@@ -2017,6 +2053,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj",
       "skos:prefLabel": "Grand Concourse Children"
     },
@@ -2057,6 +2094,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca0f",
       "skos:prefLabel": "Bronx Library Center Fiction"
     },
@@ -2067,6 +2105,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty",
       "skos:prefLabel": "Castle Hill Young Adult"
     },
@@ -2077,6 +2116,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca0l",
       "skos:prefLabel": "Bronx Library Center World Languages"
     },
@@ -2087,6 +2127,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca0n",
       "skos:prefLabel": "Bronx Library Center Non-Fiction"
     },
@@ -2107,6 +2148,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta",
       "skos:prefLabel": "Castle Hill Adult"
     },
@@ -2117,6 +2159,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca0v",
       "skos:prefLabel": "Bronx Library Center Non-Print Media"
     },
@@ -2127,6 +2170,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center for Reading & Writing",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca0w",
       "skos:prefLabel": "Bronx Library Center for Reading & Writing"
     },
@@ -2137,6 +2181,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj",
       "skos:prefLabel": "Castle Hill Children"
     },
@@ -2149,34 +2194,34 @@
       "nypl:actualLocation": "Schwarzman Building - Main Reading Room 315",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:mal"
         },
         {
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mai"
         },
         {
+          "@id": "nyplLocation:malc"
+        },
+        {
           "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:mab"
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:maf"
         }
       ],
       "nypl:owner": {
@@ -2184,7 +2229,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mal82",
       "skos:prefLabel": "SASB M1 - General Research - Room 315"
@@ -2209,6 +2254,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa0l",
       "skos:prefLabel": "Columbus World Languages"
     },
@@ -2219,6 +2265,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa0n",
       "skos:prefLabel": "Columbus Non-Fiction"
     },
@@ -2259,6 +2306,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa0f",
       "skos:prefLabel": "Columbus Fiction"
     },
@@ -2279,6 +2327,7 @@
         "@id": "nyplLocation:cc"
       },
       "nypl:actualLocation": "CCD World Lang Orders",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ccdwl",
       "skos:prefLabel": "CCD World Lang Orders"
     },
@@ -2289,6 +2338,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa0v",
       "skos:prefLabel": "Columbus Non-Print Media"
     },
@@ -2318,9 +2368,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1115"
       },
@@ -2338,6 +2385,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya0n",
       "skos:prefLabel": "Spuyten Duyvil Non-Fiction"
     },
@@ -2387,6 +2435,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca01",
       "skos:prefLabel": "Bronx Library Center Reference"
     },
@@ -2397,6 +2446,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca03",
       "skos:prefLabel": "Bronx Library Center Closed Shelf Reference"
     },
@@ -2481,14 +2531,29 @@
       "skos:prefLabel": "Macomb's Bridge Children's Reference"
     },
     {
-      "@id": "nyplLocation:ciyr",
+      "@id": "nyplLocation:sce",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ci"
+        "@id": "nyplLocation:sc"
       },
-      "nypl:actualLocation": "City Island Young Adult Reference",
-      "skos:notation": "ciyr",
-      "skos:prefLabel": "City Island Young Adult Reference"
+      "nypl:actualLocation": "Schomburg Center - Photographs & Prints",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:sc"
+      },
+      "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1118"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SP"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "sce",
+      "skos:prefLabel": "Schomburg Center - Photographs & Prints"
     },
     {
       "@id": "nyplLocation:vcj",
@@ -2670,6 +2735,17 @@
       "skos:prefLabel": "Tottenville Young Adult Reference"
     },
     {
+      "@id": "nyplLocation:bry01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:br"
+      },
+      "nypl:actualLocation": "George Bruce YA Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "bry01",
+      "skos:prefLabel": "George Bruce YA Reference"
+    },
+    {
       "@id": "nyplLocation:mbj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -2706,6 +2782,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctjr",
       "skos:prefLabel": "Castle Hill Children's Reference"
     },
@@ -2795,9 +2872,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at SIBL",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:slr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -2815,47 +2889,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -2867,12 +2900,24 @@
       "skos:prefLabel": "OFFSITE - Request in Advance"
     },
     {
+      "@id": "nyplLocation:bay01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ba"
+      },
+      "nypl:actualLocation": "Baychester YA Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "bay01",
+      "skos:prefLabel": "Baychester YA Reference"
+    },
+    {
       "@id": "nyplLocation:gdjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdjr",
       "skos:prefLabel": "Grand Concourse Children's Reference"
     },
@@ -2893,47 +2938,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -2951,6 +2955,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fejr",
       "skos:prefLabel": "58th Street Children's Reference"
     },
@@ -2961,6 +2966,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bczzz",
       "skos:prefLabel": "Bronx Library Center (error code)"
     },
@@ -2971,18 +2977,19 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa0v",
       "skos:prefLabel": "Epiphany Non-Print Media"
     },
     {
-      "@id": "nyplLocation:ndj0f",
+      "@id": "nyplLocation:wtj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nd"
+        "@id": "nyplLocation:wt"
       },
-      "nypl:actualLocation": "New Dorp Children's Fiction",
-      "skos:notation": "ndj0f",
-      "skos:prefLabel": "New Dorp Children's Fiction"
+      "nypl:actualLocation": "Westchester Square Children's Fairy Tale",
+      "skos:notation": "wtj0t",
+      "skos:prefLabel": "Westchester Square Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:epa0n",
@@ -2991,6 +2998,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa0n",
       "skos:prefLabel": "Epiphany Non-Fiction"
     },
@@ -3001,6 +3009,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa0l",
       "skos:prefLabel": "Epiphany World Languages"
     },
@@ -3031,18 +3040,40 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa0f",
       "skos:prefLabel": "Epiphany Fiction"
     },
     {
-      "@id": "nyplLocation:dha0f",
+      "@id": "nyplLocation:gkj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:gk"
       },
-      "nypl:actualLocation": "Dongan Hills Fiction",
-      "skos:notation": "dha0f",
-      "skos:prefLabel": "Dongan Hills Fiction"
+      "nypl:actualLocation": "Great Kills Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "gkj0n",
+      "skos:prefLabel": "Great Kills Children's Non-Fiction"
+    },
+    {
+      "@id": "nyplLocation:mar62",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:Ma"
+      },
+      "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:mar"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1108"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "mar62",
+      "skos:prefLabel": "SASB - Rare Book Collection Rm 328"
     },
     {
       "@id": "nyplLocation:myarv",
@@ -3051,7 +3082,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Reserve Film and Video Adult Fiction",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "skos:notation": "myarv",
       "skos:prefLabel": "Reserve Film and Video Adult Fiction"
     },
@@ -3067,26 +3098,6 @@
       },
       "skos:notation": "mma5n",
       "skos:prefLabel": "Mid-Manhattan Non-Fiction Fifth Floor"
-    },
-    {
-      "@id": "nyplLocation:malw1",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
-      },
-      "nypl:actualLocation": "Schwarzman Building - Wertheim Study Rm 228W - Reference",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:malw"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1000"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "malw1",
-      "skos:prefLabel": "SASB - Wertheim Study Rm 228W - Reference"
     },
     {
       "@id": "nyplLocation:mma5l",
@@ -3108,6 +3119,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha0n",
       "skos:prefLabel": "Dongan Hills Non-Fiction"
     },
@@ -3118,6 +3130,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha0l",
       "skos:prefLabel": "Dongan Hills World Languages"
     },
@@ -3140,6 +3153,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:dh"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha0w",
       "skos:prefLabel": "Dongan Hills Adult Learning Center"
     },
@@ -3150,6 +3164,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha0v",
       "skos:prefLabel": "Dongan Hills Non-Print Media"
     },
@@ -3180,6 +3195,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj",
       "skos:prefLabel": "Clason's Point Children"
     },
@@ -3210,6 +3226,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa03",
       "skos:prefLabel": "Epiphany Closed Shelf Reference"
     },
@@ -3220,6 +3237,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epa01",
       "skos:prefLabel": "Epiphany Reference"
     },
@@ -3260,6 +3278,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "beyr",
       "skos:prefLabel": "Belmont Young Adult Reference"
     },
@@ -3274,14 +3293,14 @@
       "skos:prefLabel": "Tompkins Square Non-Print Media"
     },
     {
-      "@id": "nyplLocation:nsj",
+      "@id": "nyplLocation:tsa0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ns"
+        "@id": "nyplLocation:ts"
       },
-      "nypl:actualLocation": "96th Street Children",
-      "skos:notation": "nsj",
-      "skos:prefLabel": "96th Street Children"
+      "nypl:actualLocation": "Tompkins Square Center for Reading & Writing",
+      "skos:notation": "tsa0w",
+      "skos:prefLabel": "Tompkins Square Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:ewy01",
@@ -3290,6 +3309,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy01",
       "skos:prefLabel": "Edenwald YA Reference"
     },
@@ -3324,17 +3344,14 @@
       "skos:prefLabel": "67th Street Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:sla0n",
+      "@id": "nyplLocation:mry0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sl"
+        "@id": "nyplLocation:mr"
       },
-      "nypl:actualLocation": "SIBL - Non-Fiction",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1125"
-      },
-      "skos:notation": "sla0n",
-      "skos:prefLabel": "SIBL - Non-Fiction"
+      "nypl:actualLocation": "Morrisania YA Non-Print Media",
+      "skos:notation": "mry0v",
+      "skos:prefLabel": "Morrisania YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:ssj0l",
@@ -3383,6 +3400,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha03",
       "skos:prefLabel": "Dongan Hills Closed Shelf Reference"
     },
@@ -3403,6 +3421,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha01",
       "skos:prefLabel": "Dongan Hills Reference"
     },
@@ -3499,6 +3518,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa0f",
       "skos:prefLabel": "Clason's Point Fiction"
     },
@@ -3586,16 +3606,6 @@
       "skos:prefLabel": "Tottenville Adult Reference"
     },
     {
-      "@id": "nyplLocation:tgar",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
-      },
-      "nypl:actualLocation": "Throg's Neck Adult Reference",
-      "skos:notation": "tgar",
-      "skos:prefLabel": "Throg's Neck Adult Reference"
-    },
-    {
       "@id": "nyplLocation:riy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -3681,47 +3691,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:map"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -3753,14 +3722,14 @@
       "skos:prefLabel": "Huguenot Park Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:muj0v",
+      "@id": "nyplLocation:hkj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:hk"
       },
-      "nypl:actualLocation": "Muhlenberg Children's Non-Print Media",
-      "skos:notation": "muj0v",
-      "skos:prefLabel": "Muhlenberg Children's Non-Print Media"
+      "nypl:actualLocation": "Huguenot Park Children's Picture Book",
+      "skos:notation": "hkj0i",
+      "skos:prefLabel": "Huguenot Park Children's Picture Book"
     },
     {
       "@id": "nyplLocation:hkj0h",
@@ -3786,7 +3755,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mab62",
       "skos:prefLabel": "SASB S6 - Art & Architecture Rm 300"
@@ -3812,12 +3781,23 @@
       "skos:prefLabel": "Huguenot Park Children's Easy Book"
     },
     {
+      "@id": "nyplLocation:rta",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:rt"
+      },
+      "nypl:actualLocation": "Richmondtown Adult",
+      "skos:notation": "rta",
+      "skos:prefLabel": "Richmondtown Adult"
+    },
+    {
       "@id": "nyplLocation:cpj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj01",
       "skos:prefLabel": "Clason's Point Children's Reference"
     },
@@ -3828,6 +3808,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eazzz",
       "skos:prefLabel": "Eastchester (error code)"
     },
@@ -3894,18 +3875,9 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0n",
       "skos:prefLabel": "Clason's Point Children's Non-Fiction"
-    },
-    {
-      "@id": "nyplLocation:rij0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ri"
-      },
-      "nypl:actualLocation": "Roosevelt Island Children's Non-Fiction",
-      "skos:notation": "rij0n",
-      "skos:prefLabel": "Roosevelt Island Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:rdj0y",
@@ -3932,7 +3904,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "map82",
       "skos:prefLabel": "SASB M1 - Map Division - Rm 117"
@@ -3944,6 +3916,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0i",
       "skos:prefLabel": "Clason's Point Children's Picture Book"
     },
@@ -3954,6 +3927,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0h",
       "skos:prefLabel": "Clason's Point Children's Holiday Book"
     },
@@ -3972,7 +3946,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "slrc3",
       "skos:prefLabel": "SIBL - B. Altman Desk"
@@ -3988,14 +3962,14 @@
       "skos:prefLabel": "Huguenot Park Children's Reference"
     },
     {
-      "@id": "nyplLocation:cpj0a",
+      "@id": "nyplLocation:rdj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:rd"
       },
-      "nypl:actualLocation": "Clason's Point Children's Easy Book",
-      "skos:notation": "cpj0a",
-      "skos:prefLabel": "Clason's Point Children's Easy Book"
+      "nypl:actualLocation": "Riverdale Children's Fairy Tale",
+      "skos:notation": "rdj0t",
+      "skos:prefLabel": "Riverdale Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:rdj0h",
@@ -4024,6 +3998,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdzzz",
       "skos:prefLabel": "125th Street (error code)"
     },
@@ -4038,24 +4013,24 @@
       "skos:prefLabel": "Morrisania YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:cpj0y",
+      "@id": "nyplLocation:rdj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:rd"
       },
-      "nypl:actualLocation": "Clason's Point Children's Young Reader",
-      "skos:notation": "cpj0y",
-      "skos:prefLabel": "Clason's Point Children's Young Reader"
+      "nypl:actualLocation": "Riverdale Children's World Languages",
+      "skos:notation": "rdj0l",
+      "skos:prefLabel": "Riverdale Children's World Languages"
     },
     {
-      "@id": "nyplLocation:nba0v",
+      "@id": "nyplLocation:otj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
+        "@id": "nyplLocation:ot"
       },
-      "nypl:actualLocation": "West New Brighton Non-Print Media",
-      "skos:notation": "nba0v",
-      "skos:prefLabel": "West New Brighton Non-Print Media"
+      "nypl:actualLocation": "Ottendorfer Children's Non-Print Media",
+      "skos:notation": "otj0v",
+      "skos:prefLabel": "Ottendorfer Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:cpj0v",
@@ -4064,6 +4039,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0v",
       "skos:prefLabel": "Clason's Point Children's Non-Print Media"
     },
@@ -4088,26 +4064,16 @@
       "skos:prefLabel": "Riverdale Children's Fiction"
     },
     {
-      "@id": "nyplLocation:sgj0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
-      },
-      "nypl:actualLocation": "St. George Children's Non-Fiction",
-      "skos:notation": "sgj0n",
-      "skos:prefLabel": "St. George Children's Non-Fiction"
-    },
-    {
       "@id": "nyplLocation:myt42",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -4145,10 +4111,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -4260,14 +4226,15 @@
       "skos:prefLabel": "South Beach Fiction"
     },
     {
-      "@id": "nyplLocation:mpy",
+      "@id": "nyplLocation:cha0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mp"
+        "@id": "nyplLocation:ch"
       },
-      "nypl:actualLocation": "Morris Park Young Adult",
-      "skos:notation": "mpy",
-      "skos:prefLabel": "Morris Park Young Adult"
+      "nypl:actualLocation": "Chatham Square World Languages",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cha0l",
+      "skos:prefLabel": "Chatham Square World Languages"
     },
     {
       "@id": "nyplLocation:otj0l",
@@ -4396,9 +4363,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mao"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -4416,6 +4380,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bry0v",
       "skos:prefLabel": "George Bruce YA Non-Print Media"
     },
@@ -4486,9 +4451,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:maq"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -4586,34 +4548,34 @@
       },
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
           "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:mal"
         },
         {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        },
+        {
           "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mai"
         }
       ],
       "nypl:owner": {
@@ -4621,7 +4583,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mal92",
       "skos:prefLabel": "SASB M2 - General Research Room 315"
@@ -4875,9 +4837,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1117"
       },
@@ -4904,9 +4863,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
       },
@@ -4922,9 +4878,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1117"
@@ -4987,17 +4940,15 @@
       "skos:prefLabel": "Stapleton Adult"
     },
     {
-      "@id": "nyplLocation:sl",
+      "@id": "nyplLocation:ewj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sl"
+        "@id": "nyplLocation:ew"
       },
-      "nypl:actualLocation": "SIBL - Science Industry and Business",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1125"
-      },
-      "skos:notation": "sl",
-      "skos:prefLabel": "SIBL - Science Industry and Business"
+      "nypl:actualLocation": "Edenwald Children",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ewj",
+      "skos:prefLabel": "Edenwald Children"
     },
     {
       "@id": "nyplLocation:sb",
@@ -5106,6 +5057,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy",
       "skos:prefLabel": "Edenwald Young Adult"
     },
@@ -5126,16 +5078,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Music",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1123"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mym22",
       "skos:prefLabel": "Performing Arts Research Collections - Music"
@@ -5197,6 +5149,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj",
       "skos:prefLabel": "Aguilar Children"
     },
@@ -5207,6 +5160,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka0f",
       "skos:prefLabel": "Great Kills Fiction"
     },
@@ -5227,6 +5181,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga",
       "skos:prefLabel": "Aguilar Adult"
     },
@@ -5267,6 +5222,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy",
       "skos:prefLabel": "Aguilar Young Adult"
     },
@@ -5357,6 +5313,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brzzz",
       "skos:prefLabel": "George Bruce (error code)"
     },
@@ -5367,6 +5324,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkar",
       "skos:prefLabel": "Great Kills Adult Reference"
     },
@@ -5397,6 +5355,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alar",
       "skos:prefLabel": "Allerton Adult Reference"
     },
@@ -5417,6 +5376,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj01",
       "skos:prefLabel": "Hamilton Fish Park Children's Reference"
     },
@@ -5457,6 +5417,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0n",
       "skos:prefLabel": "Hamilton Fish Park Children's Non-Fiction"
     },
@@ -5467,6 +5428,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0l",
       "skos:prefLabel": "Hamilton Fish Park Children's World Languages"
     },
@@ -5477,6 +5439,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0h",
       "skos:prefLabel": "Hamilton Fish Park Children's Holiday Book"
     },
@@ -5487,6 +5450,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0i",
       "skos:prefLabel": "Hamilton Fish Park Children's Picture Book"
     },
@@ -5497,6 +5461,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0f",
       "skos:prefLabel": "Hamilton Fish Park Children's Fiction"
     },
@@ -5517,6 +5482,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0a",
       "skos:prefLabel": "Hamilton Fish Park Children's Easy Book"
     },
@@ -5527,6 +5493,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0y",
       "skos:prefLabel": "Hamilton Fish Park Children's Young Reader"
     },
@@ -5537,6 +5504,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0v",
       "skos:prefLabel": "Hamilton Fish Park Children's Non-Print Media"
     },
@@ -5547,6 +5515,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj0t",
       "skos:prefLabel": "Hamilton Fish Park Children's Fairy Tale"
     },
@@ -5569,6 +5538,16 @@
       "nypl:actualLocation": "Ottendorfer Children",
       "skos:notation": "otj",
       "skos:prefLabel": "Ottendorfer Children"
+    },
+    {
+      "@id": "nyplLocation:wla03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wl"
+      },
+      "nypl:actualLocation": "Woodlawn Heights Closed Shelf Reference",
+      "skos:notation": "wla03",
+      "skos:prefLabel": "Woodlawn Heights Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:ota",
@@ -5842,6 +5821,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj",
       "skos:prefLabel": "Fort Washington Children"
     },
@@ -5882,9 +5862,11 @@
         "@id": "nyplLocation:sc"
       },
       "nypl:actualLocation": "Schomburg Center - Art & Artifacts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:sc"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1115"
       },
@@ -5897,6 +5879,17 @@
       },
       "skos:notation": "scc",
       "skos:prefLabel": "Schomburg Center - Art & Artifacts"
+    },
+    {
+      "@id": "nyplLocation:cayr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ca"
+      },
+      "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Young Adult Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cayr",
+      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference"
     },
     {
       "@id": "nyplLocation:svyr",
@@ -5953,7 +5946,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "scf",
       "skos:prefLabel": "Schomburg Center - Research & Reference"
@@ -5985,6 +5978,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy",
       "skos:prefLabel": "Columbus Young Adult"
     },
@@ -6025,9 +6019,11 @@
         "@id": "nyplLocation:sc"
       },
       "nypl:actualLocation": "Schomburg Center - Manuscripts & Archives",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:sc"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1116"
       },
@@ -6047,6 +6043,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:mm"
       },
+      "nypl:actualLocation": "Mid-Manhattan Non-Fiction Fourth Floor",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1500"
       },
@@ -6089,18 +6086,29 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha0f",
       "skos:prefLabel": "Chatham Square Fiction"
     },
     {
-      "@id": "nyplLocation:cha0l",
+      "@id": "nyplLocation:vnyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ch"
+        "@id": "nyplLocation:vn"
       },
-      "nypl:actualLocation": "Chatham Square World Languages",
-      "skos:notation": "cha0l",
-      "skos:prefLabel": "Chatham Square World Languages"
+      "nypl:actualLocation": "Van Nest Young Adult Reference",
+      "skos:notation": "vnyr",
+      "skos:prefLabel": "Pelham Parkway-Van Nest Young Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:mpy",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mp"
+      },
+      "nypl:actualLocation": "Morris Park Young Adult",
+      "skos:notation": "mpy",
+      "skos:prefLabel": "Morris Park Young Adult"
     },
     {
       "@id": "nyplLocation:kpyr",
@@ -6119,6 +6127,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha0n",
       "skos:prefLabel": "Chatham Square Non-Fiction"
     },
@@ -6139,6 +6148,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha0v",
       "skos:prefLabel": "Chatham Square Non-Print Media"
     },
@@ -6148,6 +6158,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ch"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha0w",
       "skos:prefLabel": "Chatham Adult Learning Center"
     },
@@ -6212,6 +6223,26 @@
       "skos:prefLabel": "Wakefield Young Adult Reference"
     },
     {
+      "@id": "nyplLocation:qcml2",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:qc"
+      },
+      "nypl:actualLocation": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:mal"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "qcml2",
+      "skos:prefLabel": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg -"
+    },
+    {
       "@id": "nyplLocation:malm2",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -6220,13 +6251,7 @@
       "nypl:actualLocation": "Schwarzman Building - Main Reading Room 315 - Mezzanine",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:malw"
@@ -6235,19 +6260,25 @@
           "@id": "nyplLocation:mag"
         },
         {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
           "@id": "nyplLocation:mal"
         },
         {
           "@id": "nyplLocation:mai"
         },
         {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:maf"
         }
       ],
       "nypl:owner": {
@@ -6255,7 +6286,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "malm2",
       "skos:prefLabel": "SASB - General Research - Room 315"
@@ -6287,6 +6318,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epyr",
       "skos:prefLabel": "Epiphany Young Adult Reference"
     },
@@ -6297,6 +6329,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha01",
       "skos:prefLabel": "Chatham Square Reference"
     },
@@ -6307,6 +6340,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cha03",
       "skos:prefLabel": "Chatham Square Closed Shelf Reference"
     },
@@ -6337,6 +6371,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxzzz",
       "skos:prefLabel": "Francis Martin (error code)"
     },
@@ -6421,15 +6456,23 @@
       "skos:prefLabel": "Melrose Children's Young Reader"
     },
     {
+      "@id": "nyplLocation:fea0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:fe"
+      },
+      "nypl:actualLocation": "58th Street Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fea0v",
+      "skos:prefLabel": "58th Street Non-Print Media"
+    },
+    {
       "@id": "nyplLocation:rcml2",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg Main Reading Room 315",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mal"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -6537,6 +6580,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla0v",
       "skos:prefLabel": "Bloomingdale Non-Print Media"
     },
@@ -6547,6 +6591,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj01",
       "skos:prefLabel": "Allerton Children's Reference"
     },
@@ -6557,6 +6602,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy0v",
       "skos:prefLabel": "Bronx Library Center YA Non-Print Media"
     },
@@ -6567,6 +6613,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy0l",
       "skos:prefLabel": "Bronx Library Center YA World Languages"
     },
@@ -6577,6 +6624,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy0n",
       "skos:prefLabel": "Bronx Library Center YA Non-Fiction"
     },
@@ -6587,6 +6635,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla0f",
       "skos:prefLabel": "Bloomingdale Fiction"
     },
@@ -6597,6 +6646,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla0l",
       "skos:prefLabel": "Bloomingdale World Languages"
     },
@@ -6607,6 +6657,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy0f",
       "skos:prefLabel": "Bronx Library Center YA Fiction"
     },
@@ -6617,6 +6668,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla0n",
       "skos:prefLabel": "Bloomingdale Non-Fiction"
     },
@@ -6627,6 +6679,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhyr",
       "skos:prefLabel": "Dongan Hills Young Adult Reference"
     },
@@ -6657,6 +6710,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btjr",
       "skos:prefLabel": "Battery Park Children's Reference"
     },
@@ -6677,6 +6731,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbzzz",
       "skos:prefLabel": "High Bridge (error code)"
     },
@@ -6697,6 +6752,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj01",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Reference"
     },
@@ -6737,6 +6793,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla01",
       "skos:prefLabel": "Bloomingdale Reference"
     },
@@ -6747,6 +6804,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla03",
       "skos:prefLabel": "Bloomingdale Closed Shelf Reference"
     },
@@ -6757,9 +6815,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -6777,6 +6832,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy01",
       "skos:prefLabel": "Bronx Library Center YA Reference"
     },
@@ -6806,9 +6862,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -6820,14 +6873,14 @@
       "skos:prefLabel": "OFFSITE - Request in Advance for use at Performing Arts"
     },
     {
-      "@id": "nyplLocation:alj0v",
+      "@id": "nyplLocation:pkar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:al"
+        "@id": "nyplLocation:pk"
       },
-      "nypl:actualLocation": "Allerton Children's Non-Print Media",
-      "skos:notation": "alj0v",
-      "skos:prefLabel": "Allerton Children's Non-Print Media"
+      "nypl:actualLocation": "Parkchester Adult Reference",
+      "skos:notation": "pkar",
+      "skos:prefLabel": "Parkchester Adult Reference"
     },
     {
       "@id": "nyplLocation:alj0i",
@@ -6836,6 +6889,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0i",
       "skos:prefLabel": "Allerton Children's Picture Book"
     },
@@ -6846,6 +6900,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0h",
       "skos:prefLabel": "Allerton Children's Holiday Book"
     },
@@ -6866,6 +6921,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0l",
       "skos:prefLabel": "Allerton Children's World Languages"
     },
@@ -6876,6 +6932,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0n",
       "skos:prefLabel": "Allerton Children's Non-Fiction"
     },
@@ -6886,6 +6943,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0a",
       "skos:prefLabel": "Allerton Children's Easy Book"
     },
@@ -6906,6 +6964,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0f",
       "skos:prefLabel": "Allerton Children's Fiction"
     },
@@ -6916,6 +6975,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa0f",
       "skos:prefLabel": "Edenwald Fiction"
     },
@@ -6926,6 +6986,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda0v",
       "skos:prefLabel": "Grand Concourse Non-Print Media"
     },
@@ -6946,6 +7007,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa0n",
       "skos:prefLabel": "Edenwald Non-Fiction"
     },
@@ -6956,6 +7018,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa0l",
       "skos:prefLabel": "Edenwald World Languages"
     },
@@ -6996,6 +7059,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa0v",
       "skos:prefLabel": "Edenwald Non-Print Media"
     },
@@ -7006,6 +7070,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda0f",
       "skos:prefLabel": "Grand Concourse Fiction"
     },
@@ -7036,6 +7101,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda0l",
       "skos:prefLabel": "Grand Concourse World Languages"
     },
@@ -7046,6 +7112,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda0n",
       "skos:prefLabel": "Grand Concourse Non-Fiction"
     },
@@ -7066,6 +7133,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0h",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Holiday Book"
     },
@@ -7155,14 +7223,14 @@
       "skos:prefLabel": "Webster Children's Reference"
     },
     {
-      "@id": "nyplLocation:moj01",
+      "@id": "nyplLocation:tmj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mo"
+        "@id": "nyplLocation:tm"
       },
-      "nypl:actualLocation": "Mosholu Children's Reference",
-      "skos:notation": "moj01",
-      "skos:prefLabel": "Mosholu Children's Reference"
+      "nypl:actualLocation": "Tremont Children's Young Reader",
+      "skos:notation": "tmj0y",
+      "skos:prefLabel": "Tremont Children's Young Reader"
     },
     {
       "@id": "nyplLocation:saj",
@@ -7180,6 +7248,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftjr",
       "skos:prefLabel": "53rd Street Children's Reference"
     },
@@ -7230,6 +7299,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda01",
       "skos:prefLabel": "Grand Concourse Reference"
     },
@@ -7240,6 +7310,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gda03",
       "skos:prefLabel": "Grand Concourse Closed Shelf Reference"
     },
@@ -7283,6 +7354,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa03",
       "skos:prefLabel": "Edenwald Closed Shelf Reference"
     },
@@ -7305,6 +7377,16 @@
       "nypl:actualLocation": "St. George YA Non-Print Media",
       "skos:notation": "sgy0v",
       "skos:prefLabel": "St. George YA Non-Print Media"
+    },
+    {
+      "@id": "nyplLocation:nba0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:nb"
+      },
+      "nypl:actualLocation": "West New Brighton Non-Print Media",
+      "skos:notation": "nba0v",
+      "skos:prefLabel": "West New Brighton Non-Print Media"
     },
     {
       "@id": "nyplLocation:moj0f",
@@ -7417,16 +7499,6 @@
       "skos:prefLabel": "Pelham Bay Fiction"
     },
     {
-      "@id": "nyplLocation:sgj0a",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
-      },
-      "nypl:actualLocation": "St. George Children's Easy Book",
-      "skos:notation": "sgj0a",
-      "skos:prefLabel": "St. George Children's Easy Book"
-    },
-    {
       "@id": "nyplLocation:pma0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -7453,6 +7525,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cly01",
       "skos:prefLabel": "Morningside Heights YA Reference"
     },
@@ -7473,16 +7546,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Dance",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myd22",
       "skos:prefLabel": "Performing Arts Research Collections - Dance"
@@ -7654,6 +7727,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cly0f",
       "skos:prefLabel": "Morningside Heights YA Fiction"
     },
@@ -7674,6 +7748,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cly0l",
       "skos:prefLabel": "Morningside Heights YA World Languages"
     },
@@ -7688,14 +7763,14 @@
       "skos:prefLabel": "Morrisania Adult Reference"
     },
     {
-      "@id": "nyplLocation:cly0n",
+      "@id": "nyplLocation:lma",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cl"
+        "@id": "nyplLocation:lm"
       },
-      "nypl:actualLocation": "Morningside Heights YA Non-Fiction",
-      "skos:notation": "cly0n",
-      "skos:prefLabel": "Morningside Heights YA Non-Fiction"
+      "nypl:actualLocation": "New Amsterdam Adult",
+      "skos:notation": "lma",
+      "skos:prefLabel": "New Amsterdam Adult"
     },
     {
       "@id": "nyplLocation:pma01",
@@ -7794,6 +7869,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baar",
       "skos:prefLabel": "Baychester Adult Reference"
     },
@@ -8024,6 +8100,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0i",
       "skos:prefLabel": "Baychester Children's Picture Book"
     },
@@ -8034,6 +8111,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0h",
       "skos:prefLabel": "Baychester Children's Holiday Book"
     },
@@ -8060,11 +8138,16 @@
     {
       "@id": "nyplLocation:max",
       "@type": "nypl:Location",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:max"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NX"
       },
       "skos:notation": "max",
-      "skos:prefLabel": ""
+      "skos:prefLabel": "SASB - Preservation"
     },
     {
       "@id": "nyplLocation:baj0n",
@@ -8073,6 +8156,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0n",
       "skos:prefLabel": "Baychester Children's Non-Fiction"
     },
@@ -8083,6 +8167,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0a",
       "skos:prefLabel": "Baychester Children's Easy Book"
     },
@@ -8113,9 +8198,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mar"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1108"
       },
@@ -8146,9 +8233,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Map Division - Rm 117",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:map"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1106"
       },
@@ -8157,7 +8246,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "map",
       "skos:prefLabel": "SASB - Map Division - Rm 117"
@@ -8179,6 +8268,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0y",
       "skos:prefLabel": "Baychester Children's Young Reader"
     },
@@ -8189,9 +8279,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Manuscripts & Archives Rm 328",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mao"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1107"
       },
@@ -8212,9 +8304,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Main Reading Room 315",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mal"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -8223,7 +8317,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mal",
       "skos:prefLabel": "SASB - Service Desk Rm 315"
@@ -8251,11 +8345,16 @@
     {
       "@id": "nyplLocation:lsca",
       "@type": "nypl:Location",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:lsca"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NY"
       },
       "skos:notation": "lsca",
-      "skos:prefLabel": ""
+      "skos:prefLabel": "LSC - Archives Unit"
     },
     {
       "@id": "nyplLocation:huj0t",
@@ -8274,9 +8373,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Dorot Jewish Division Rm 111",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:maf"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1103"
       },
@@ -8285,7 +8386,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "maf",
       "skos:prefLabel": "SASB - Dorot Jewish Division Rm 111"
@@ -8297,14 +8398,16 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Milstein Division Rm 121",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mag"
         }
       ],
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1105"
       },
@@ -8313,7 +8416,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mag",
       "skos:prefLabel": "SASB - Milstein Division Rm 121"
@@ -8345,14 +8448,20 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Art & Architecture Rm 300",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mab"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1110"
       },
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
       "skos:notation": "mab",
       "skos:prefLabel": "SASB - Art & Architecture Rm 300"
@@ -8364,6 +8473,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0t",
       "skos:prefLabel": "Baychester Children's Fairy Tale"
     },
@@ -8374,6 +8484,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0v",
       "skos:prefLabel": "Baychester Children's Non-Print Media"
     },
@@ -8424,6 +8535,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfjr",
       "skos:prefLabel": "Hamilton Fish Park Children's Reference"
     },
@@ -8456,6 +8568,17 @@
       "nypl:actualLocation": "Wakefield Fiction",
       "skos:notation": "wka0f",
       "skos:prefLabel": "Wakefield Fiction"
+    },
+    {
+      "@id": "nyplLocation:cpj0a",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:cp"
+      },
+      "nypl:actualLocation": "Clason's Point Children's Easy Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cpj0a",
+      "skos:prefLabel": "Clason's Point Children's Easy Book"
     },
     {
       "@id": "nyplLocation:jmj",
@@ -8498,14 +8621,25 @@
       "skos:prefLabel": "Woodlawn Heights Children's Fiction"
     },
     {
-      "@id": "nyplLocation:wka0w",
+      "@id": "nyplLocation:myh42",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wk"
+        "@id": "nyplLocation:my"
       },
-      "nypl:actualLocation": "Wakefield Center for Reading & Writing",
-      "skos:notation": "wka0w",
-      "skos:prefLabel": "Wakefield Center for Reading & Writing"
+      "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "myh42",
+      "skos:prefLabel": "OFFSITE Rose - Request in advance for use at Performing Arts"
     },
     {
       "@id": "nyplLocation:wka0v",
@@ -8572,7 +8706,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "slra3",
       "skos:prefLabel": "SIBL - B. Altman Reference Desk"
@@ -8594,6 +8728,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj01",
       "skos:prefLabel": "Baychester Children's Reference"
     },
@@ -8604,6 +8739,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewj0n",
       "skos:prefLabel": "Edenwald Children's Non-Fiction"
     },
@@ -8614,6 +8750,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agyr",
       "skos:prefLabel": "Aguilar Young Adult Reference"
     },
@@ -8634,6 +8771,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra0n",
       "skos:prefLabel": "George Bruce Non-Fiction"
     },
@@ -8644,10 +8782,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections  Theatre",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1119"
       },
@@ -8665,6 +8803,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra0l",
       "skos:prefLabel": "George Bruce World Languages"
     },
@@ -8675,16 +8814,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Theatre",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1119"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myt22",
       "skos:prefLabel": "Performing Arts Research Collections - Theatre"
@@ -8696,6 +8835,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra0f",
       "skos:prefLabel": "George Bruce Fiction"
     },
@@ -8759,6 +8899,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bljr",
       "skos:prefLabel": "Bloomingdale Children's Reference"
     },
@@ -8788,6 +8929,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda01",
       "skos:prefLabel": "125th Street Reference"
     },
@@ -8822,6 +8964,16 @@
       "skos:prefLabel": "Webster Children"
     },
     {
+      "@id": "nyplLocation:woj0h",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wo"
+      },
+      "nypl:actualLocation": "Woodstock Children's Holiday Book",
+      "skos:notation": "woj0h",
+      "skos:prefLabel": "Woodstock Children's Holiday Book"
+    },
+    {
       "@id": "nyplLocation:wby",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -8838,6 +8990,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra01",
       "skos:prefLabel": "George Bruce Reference"
     },
@@ -8858,6 +9011,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda0n",
       "skos:prefLabel": "125th Street Non-Fiction"
     },
@@ -8868,6 +9022,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda0l",
       "skos:prefLabel": "125th Street World Languages"
     },
@@ -8878,18 +9033,20 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda0f",
       "skos:prefLabel": "125th Street Fiction"
     },
     {
-      "@id": "nyplLocation:kba03",
+      "@id": "nyplLocation:hda0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:kb"
+        "@id": "nyplLocation:hd"
       },
-      "nypl:actualLocation": "Kingsbridge Closed Shelf Reference",
-      "skos:notation": "kba03",
-      "skos:prefLabel": "Kingsbridge Closed Shelf Reference"
+      "nypl:actualLocation": "125th Street Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hda0v",
+      "skos:prefLabel": "125th Street Non-Print Media"
     },
     {
       "@id": "nyplLocation:kba01",
@@ -8902,14 +9059,14 @@
       "skos:prefLabel": "Kingsbridge Reference"
     },
     {
-      "@id": "nyplLocation:hbj0y",
+      "@id": "nyplLocation:tgj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hb"
+        "@id": "nyplLocation:tg"
       },
-      "nypl:actualLocation": "High Bridge Children's Young Reader",
-      "skos:notation": "hbj0y",
-      "skos:prefLabel": "High Bridge Children's Young Reader"
+      "nypl:actualLocation": "Throg's Neck Children's Non-Fiction",
+      "skos:notation": "tgj0n",
+      "skos:prefLabel": "Throg's Neck Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:tgj0i",
@@ -8928,6 +9085,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0v",
       "skos:prefLabel": "High Bridge Children's Non-Print Media"
     },
@@ -8947,6 +9105,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0t",
       "skos:prefLabel": "High Bridge Children's Fairy Tale"
     },
@@ -8970,6 +9129,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cazzz",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral (error code)"
     },
@@ -8980,6 +9140,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0h",
       "skos:prefLabel": "High Bridge Children's Holiday Book"
     },
@@ -8990,6 +9151,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0i",
       "skos:prefLabel": "High Bridge Children's Picture Book"
     },
@@ -9010,6 +9172,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0l",
       "skos:prefLabel": "High Bridge Children's World Languages"
     },
@@ -9020,6 +9183,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj01",
       "skos:prefLabel": "Morningside Heights Children's Reference"
     },
@@ -9030,6 +9194,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0a",
       "skos:prefLabel": "High Bridge Children's Easy Book"
     },
@@ -9040,6 +9205,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0f",
       "skos:prefLabel": "High Bridge Children's Fiction"
     },
@@ -9050,6 +9216,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btyr",
       "skos:prefLabel": "Battery Park Young Adult Reference"
     },
@@ -9074,14 +9241,14 @@
       "skos:prefLabel": "Hunt's Point Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:thjr",
+      "@id": "nyplLocation:wta01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:th"
+        "@id": "nyplLocation:wt"
       },
-      "nypl:actualLocation": "Todt Hill-Westerleigh Children's Reference",
-      "skos:notation": "thjr",
-      "skos:prefLabel": "Todt Hill-Westerleigh Children's Reference"
+      "nypl:actualLocation": "Westchester Square Reference",
+      "skos:notation": "wta01",
+      "skos:prefLabel": "Westchester Square Reference"
     },
     {
       "@id": "nyplLocation:masu2",
@@ -9104,14 +9271,14 @@
       "skos:prefLabel": "SASB - Photography Collection Rm 308"
     },
     {
-      "@id": "nyplLocation:wta03",
+      "@id": "nyplLocation:pra0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:pr"
       },
-      "nypl:actualLocation": "Westchester Square Closed Shelf Reference",
-      "skos:notation": "wta03",
-      "skos:prefLabel": "Westchester Square Closed Shelf Reference"
+      "nypl:actualLocation": "Port Richmond Fiction",
+      "skos:notation": "pra0f",
+      "skos:prefLabel": "Port Richmond Fiction"
     },
     {
       "@id": "nyplLocation:maf99",
@@ -9222,14 +9389,25 @@
       "skos:prefLabel": "Port Richmond Non-Print Media"
     },
     {
-      "@id": "nyplLocation:hsj0y",
+      "@id": "nyplLocation:mym38",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hs"
+        "@id": "nyplLocation:my"
       },
-      "nypl:actualLocation": "Hunt's Point Children's Young Reader",
-      "skos:notation": "hsj0y",
-      "skos:prefLabel": "Hunt's Point Children's Young Reader"
+      "nypl:actualLocation": "Performing Arts Research Collections - Music",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1123"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "mym38",
+      "skos:prefLabel": "Performing Arts Research Collections - Music"
     },
     {
       "@id": "nyplLocation:fwyr",
@@ -9238,28 +9416,30 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwyr",
       "skos:prefLabel": "Fort Washington Young Adult Reference"
     },
     {
-      "@id": "nyplLocation:wfj0n",
+      "@id": "nyplLocation:tsy0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wf"
+        "@id": "nyplLocation:ts"
       },
-      "nypl:actualLocation": "West Farms Children's Non-Fiction",
-      "skos:notation": "wfj0n",
-      "skos:prefLabel": "West Farms Children's Non-Fiction"
+      "nypl:actualLocation": "Tompkins Square YA World Languages",
+      "skos:notation": "tsy0l",
+      "skos:prefLabel": "Tompkins Square YA World Languages"
     },
     {
-      "@id": "nyplLocation:alzzz",
+      "@id": "nyplLocation:fey",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:al"
+        "@id": "nyplLocation:fe"
       },
-      "nypl:actualLocation": "Allerton (error code)",
-      "skos:notation": "alzzz",
-      "skos:prefLabel": "Allerton (error code)"
+      "nypl:actualLocation": "58th Street Young Adult",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fey",
+      "skos:prefLabel": "58th Street Young Adult"
     },
     {
       "@id": "nyplLocation:clj0i",
@@ -9268,6 +9448,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0i",
       "skos:prefLabel": "Morningside Heights Children's Picture Book"
     },
@@ -9288,6 +9469,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0n",
       "skos:prefLabel": "Morningside Heights Children's Non-Fiction"
     },
@@ -9298,6 +9480,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0l",
       "skos:prefLabel": "Morningside Heights Children's World Languages"
     },
@@ -9328,6 +9511,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0a",
       "skos:prefLabel": "Morningside Heights Children's Easy Book"
     },
@@ -9338,6 +9522,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj01",
       "skos:prefLabel": "High Bridge Children's Reference"
     },
@@ -9348,6 +9533,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0f",
       "skos:prefLabel": "Morningside Heights Children's Fiction"
     },
@@ -9368,6 +9554,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cizzz",
       "skos:prefLabel": "City Island (error code)"
     },
@@ -9378,6 +9565,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0y",
       "skos:prefLabel": "Morningside Heights Children's Young Reader"
     },
@@ -9392,25 +9580,13 @@
       "skos:prefLabel": "Todt Hill-Westerleigh Reference"
     },
     {
-      "@id": "nyplLocation:Mar-82",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:Ma"
-      },
-      "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1108"
-      },
-      "skos:notation": "Mar-82",
-      "skos:prefLabel": "SASB - Rare Book Collection Rm 328"
-    },
-    {
       "@id": "nyplLocation:cijr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cijr",
       "skos:prefLabel": "City Island Children's Reference"
     },
@@ -9421,6 +9597,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0v",
       "skos:prefLabel": "Morningside Heights Children's Non-Print Media"
     },
@@ -9441,6 +9618,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0t",
       "skos:prefLabel": "Morningside Heights Children's Fairy Tale"
     },
@@ -9480,6 +9658,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpar",
       "skos:prefLabel": "Clason's Point Adult Reference"
     },
@@ -9500,6 +9679,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0n",
       "skos:prefLabel": "Epiphany Children's Non-Fiction"
     },
@@ -9514,14 +9694,14 @@
       "skos:prefLabel": "Westchester Square Young Adult"
     },
     {
-      "@id": "nyplLocation:bezzz",
+      "@id": "nyplLocation:tha0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:be"
+        "@id": "nyplLocation:th"
       },
-      "nypl:actualLocation": "Belmont (error code)",
-      "skos:notation": "bezzz",
-      "skos:prefLabel": "Belmont (error code)"
+      "nypl:actualLocation": "Todt Hill-Westerleigh Non-Fiction",
+      "skos:notation": "tha0n",
+      "skos:prefLabel": "Todt Hill-Westerleigh Non-Fiction"
     },
     {
       "@id": "nyplLocation:pra01",
@@ -9534,24 +9714,25 @@
       "skos:prefLabel": "Port Richmond Reference"
     },
     {
-      "@id": "nyplLocation:sgj0f",
+      "@id": "nyplLocation:epj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:ep"
       },
-      "nypl:actualLocation": "St. George Children's Fiction",
-      "skos:notation": "sgj0f",
-      "skos:prefLabel": "St. George Children's Fiction"
+      "nypl:actualLocation": "Epiphany Children's Easy Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "epj0a",
+      "skos:prefLabel": "Epiphany Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:wta0f",
+      "@id": "nyplLocation:yva",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:yv"
       },
-      "nypl:actualLocation": "Westchester Square Fiction",
-      "skos:notation": "wta0f",
-      "skos:prefLabel": "Westchester Square Fiction"
+      "nypl:actualLocation": "Yorkville Adult",
+      "skos:notation": "yva",
+      "skos:prefLabel": "Yorkville Adult"
     },
     {
       "@id": "nyplLocation:maj0a",
@@ -9627,16 +9808,6 @@
       "skos:prefLabel": "West Farms Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:prj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
-      },
-      "nypl:actualLocation": "Port Richmond Children's Non-Print Media",
-      "skos:notation": "prj0v",
-      "skos:prefLabel": "Port Richmond Children's Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:wtj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -9662,6 +9833,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftyr",
       "skos:prefLabel": "53rd Street Young Adult Reference"
     },
@@ -9672,6 +9844,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0t",
       "skos:prefLabel": "Allerton Children's Fairy Tale"
     },
@@ -9696,14 +9869,14 @@
       "skos:prefLabel": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg -"
     },
     {
-      "@id": "nyplLocation:pkar",
+      "@id": "nyplLocation:sgj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:sg"
       },
-      "nypl:actualLocation": "Parkchester Adult Reference",
-      "skos:notation": "pkar",
-      "skos:prefLabel": "Parkchester Adult Reference"
+      "nypl:actualLocation": "St. George Children's Easy Book",
+      "skos:notation": "sgj0a",
+      "skos:prefLabel": "St. George Children's Easy Book"
     },
     {
       "@id": "nyplLocation:ota0l",
@@ -9716,14 +9889,14 @@
       "skos:prefLabel": "Ottendorfer World Languages"
     },
     {
-      "@id": "nyplLocation:ota0n",
+      "@id": "nyplLocation:nbj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:nb"
       },
-      "nypl:actualLocation": "Ottendorfer Non-Fiction",
-      "skos:notation": "ota0n",
-      "skos:prefLabel": "Ottendorfer Non-Fiction"
+      "nypl:actualLocation": "West New Brighton Children's Non-Fiction",
+      "skos:notation": "nbj0n",
+      "skos:prefLabel": "West New Brighton Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:btj0y",
@@ -9732,6 +9905,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0y",
       "skos:prefLabel": "Battery Park Children's Young Reader"
     },
@@ -9776,14 +9950,14 @@
       "skos:prefLabel": "New Dorp Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:sga0w",
+      "@id": "nyplLocation:ota0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:ot"
       },
-      "nypl:actualLocation": "St. George Center for Reading & Writing",
-      "skos:notation": "sga0w",
-      "skos:prefLabel": "St. George Center for Reading & Writing"
+      "nypl:actualLocation": "Ottendorfer Fiction",
+      "skos:notation": "ota0f",
+      "skos:prefLabel": "Ottendorfer Fiction"
     },
     {
       "@id": "nyplLocation:sga0v",
@@ -9802,6 +9976,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0v",
       "skos:prefLabel": "Battery Park Children's Non-Print Media"
     },
@@ -9882,6 +10057,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0n",
       "skos:prefLabel": "Battery Park Children's Non-Fiction"
     },
@@ -9902,6 +10078,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0l",
       "skos:prefLabel": "Battery Park Children's World Languages"
     },
@@ -9922,6 +10099,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdyr",
       "skos:prefLabel": "Grand Concourse Young Adult Reference"
     },
@@ -9952,6 +10130,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0f",
       "skos:prefLabel": "Battery Park Children's Fiction"
     },
@@ -9995,7 +10174,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Library (error code)",
-      "nypl:locationType": "Both",
+      "nypl:collectionType": [
+        "Research",
+        "Branch"
+      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -10022,14 +10204,14 @@
       "skos:prefLabel": "Research Libraries - On Order"
     },
     {
-      "@id": "nyplLocation:fea",
+      "@id": "nyplLocation:sgj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:sg"
       },
-      "nypl:actualLocation": "58th Street Adult",
-      "skos:notation": "fea",
-      "skos:prefLabel": "58th Street Adult"
+      "nypl:actualLocation": "St. George Children's Non-Print Media",
+      "skos:notation": "sgj0v",
+      "skos:prefLabel": "St. George Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:vnj",
@@ -10048,10 +10230,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections  Dance",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
@@ -10073,32 +10255,22 @@
       "skos:prefLabel": "Pelham Parkway-Van Nest Adult"
     },
     {
-      "@id": "nyplLocation:mea0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:me"
-      },
-      "nypl:actualLocation": "Melrose Non-Print Media",
-      "skos:notation": "mea0v",
-      "skos:prefLabel": "Melrose Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:myd32",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Dance",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myd32",
       "skos:prefLabel": "Performing Arts Research Collections - Dance"
@@ -10110,6 +10282,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cajr",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Reference"
     },
@@ -10130,6 +10303,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj01",
       "skos:prefLabel": "Battery Park Children's Reference"
     },
@@ -10160,8 +10334,20 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky",
       "skos:prefLabel": "Great Kills Young Adult"
+    },
+    {
+      "@id": "nyplLocation:epy01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ep"
+      },
+      "nypl:actualLocation": "Epiphany YA Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "epy01",
+      "skos:prefLabel": "Epiphany YA Reference"
     },
     {
       "@id": "nyplLocation:ndj01",
@@ -10190,6 +10376,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj",
       "skos:prefLabel": "Great Kills Children"
     },
@@ -10220,6 +10407,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0y",
       "skos:prefLabel": "George Bruce Children's Young Reader"
     },
@@ -10240,6 +10428,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay0n",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA Non-Fiction"
     },
@@ -10260,6 +10449,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala0f",
       "skos:prefLabel": "Allerton Fiction"
     },
@@ -10280,6 +10470,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0t",
       "skos:prefLabel": "George Bruce Children's Fairy Tale"
     },
@@ -10294,14 +10485,15 @@
       "skos:prefLabel": "96th Street YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:sbj0i",
+      "@id": "nyplLocation:brj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sb"
+        "@id": "nyplLocation:br"
       },
-      "nypl:actualLocation": "South Beach Children's Picture Book",
-      "skos:notation": "sbj0i",
-      "skos:prefLabel": "South Beach Children's Picture Book"
+      "nypl:actualLocation": "George Bruce Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "brj0v",
+      "skos:prefLabel": "George Bruce Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:brj0h",
@@ -10310,6 +10502,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0h",
       "skos:prefLabel": "George Bruce Children's Holiday Book"
     },
@@ -10320,6 +10513,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0i",
       "skos:prefLabel": "George Bruce Children's Picture Book"
     },
@@ -10330,6 +10524,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj01",
       "skos:prefLabel": "Bronx Library Center Children's Reference"
     },
@@ -10340,6 +10535,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0l",
       "skos:prefLabel": "George Bruce Children's World Languages"
     },
@@ -10360,6 +10556,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0n",
       "skos:prefLabel": "George Bruce Children's Non-Fiction"
     },
@@ -10370,6 +10567,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0a",
       "skos:prefLabel": "George Bruce Children's Easy Book"
     },
@@ -10380,6 +10578,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj0f",
       "skos:prefLabel": "George Bruce Children's Fiction"
     },
@@ -10394,12 +10593,23 @@
       "skos:prefLabel": "St. George YA Non-Fiction"
     },
     {
+      "@id": "nyplLocation:stj0a",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:st"
+      },
+      "nypl:actualLocation": "Stapleton Children's Easy Book",
+      "skos:notation": "stj0a",
+      "skos:prefLabel": "Stapleton Children's Easy Book"
+    },
+    {
       "@id": "nyplLocation:hdj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj01",
       "skos:prefLabel": "125th Street Children's Reference"
     },
@@ -10423,6 +10633,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly0l",
       "skos:prefLabel": "Bloomingdale YA World Languages"
     },
@@ -10433,6 +10644,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay0f",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA Fiction"
     },
@@ -10453,6 +10665,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly0f",
       "skos:prefLabel": "Bloomingdale YA Fiction"
     },
@@ -10463,6 +10676,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brar",
       "skos:prefLabel": "George Bruce Adult Reference"
     },
@@ -10473,6 +10687,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0a",
       "skos:prefLabel": "Bronx Library Center Children's Easy Book"
     },
@@ -10483,6 +10698,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0f",
       "skos:prefLabel": "Bronx Library Center Children's Fiction"
     },
@@ -10493,6 +10709,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka",
       "skos:prefLabel": "Great Kills Adult"
     },
@@ -10503,6 +10720,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "brj01",
       "skos:prefLabel": "George Bruce Children's Reference"
     },
@@ -10513,6 +10731,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0i",
       "skos:prefLabel": "Bronx Library Center Children's Picture Book"
     },
@@ -10523,6 +10742,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0h",
       "skos:prefLabel": "Bronx Library Center Children's Holiday Book"
     },
@@ -10533,38 +10753,41 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0n",
       "skos:prefLabel": "Bronx Library Center Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:woa0v",
+      "@id": "nyplLocation:gk",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:gk"
+      },
+      "nypl:actualLocation": "Great Kills",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "gk",
+      "skos:prefLabel": "Great Kills"
+    },
+    {
+      "@id": "nyplLocation:dyj0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:dy"
+      },
+      "nypl:actualLocation": "Spuyten Duyvil Children's Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "dyj0f",
+      "skos:prefLabel": "Spuyten Duyvil Children's Fiction"
+    },
+    {
+      "@id": "nyplLocation:woa0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:wo"
       },
-      "nypl:actualLocation": "Woodstock Non-Print Media",
-      "skos:notation": "woa0v",
-      "skos:prefLabel": "Woodstock Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:qcml2",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:qc"
-      },
-      "nypl:actualLocation": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mal"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1000"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "qcml2",
-      "skos:prefLabel": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg -"
+      "nypl:actualLocation": "Woodstock World Languages",
+      "skos:notation": "woa0l",
+      "skos:prefLabel": "Woodstock World Languages"
     },
     {
       "@id": "nyplLocation:woa0n",
@@ -10583,6 +10806,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0y",
       "skos:prefLabel": "Bronx Library Center Children's Young Reader"
     },
@@ -10592,6 +10816,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj01",
       "skos:prefLabel": "53rd Street Children's Reference"
     },
@@ -10612,6 +10837,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0y",
       "skos:prefLabel": "125th Street Children's Young Reader"
     },
@@ -10648,6 +10874,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0t",
       "skos:prefLabel": "125th Street Children's Fairy Tale"
     },
@@ -10668,21 +10895,20 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0v",
       "skos:prefLabel": "125th Street Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:slajn",
+      "@id": "nyplLocation:hdj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sl"
+        "@id": "nyplLocation:hd"
       },
-      "nypl:actualLocation": "SIBL - Job Search Central Non-Fiction",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1125"
-      },
-      "skos:notation": "slajn",
-      "skos:prefLabel": "SIBL - Job Search Central Non-Fiction"
+      "nypl:actualLocation": "125th Street Children's Holiday Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hdj0h",
+      "skos:prefLabel": "125th Street Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:hdj0i",
@@ -10691,6 +10917,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0i",
       "skos:prefLabel": "125th Street Children's Picture Book"
     },
@@ -10701,6 +10928,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0l",
       "skos:prefLabel": "125th Street Children's World Languages"
     },
@@ -10711,6 +10939,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0n",
       "skos:prefLabel": "125th Street Children's Non-Fiction"
     },
@@ -10721,6 +10950,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0a",
       "skos:prefLabel": "125th Street Children's Easy Book"
     },
@@ -10731,6 +10961,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj0f",
       "skos:prefLabel": "125th Street Children's Fiction"
     },
@@ -10741,6 +10972,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy0n",
       "skos:prefLabel": "Edenwald YA Non-Fiction"
     },
@@ -10761,6 +10993,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy0l",
       "skos:prefLabel": "Edenwald YA World Languages"
     },
@@ -10771,6 +11004,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla01",
       "skos:prefLabel": "Morningside Heights Reference"
     },
@@ -10781,6 +11015,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy0v",
       "skos:prefLabel": "Chatham Square YA Non-Print Media"
     },
@@ -10791,6 +11026,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla03",
       "skos:prefLabel": "Morningside Heights Closed Shelf Reference"
     },
@@ -10811,6 +11047,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy0l",
       "skos:prefLabel": "Chatham Square YA World Languages"
     },
@@ -10831,6 +11068,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy0n",
       "skos:prefLabel": "Chatham Square YA Non-Fiction"
     },
@@ -10861,6 +11099,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay0v",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA Non-Print Media"
     },
@@ -10871,6 +11110,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa0v",
       "skos:prefLabel": "Baychester Non-Print Media"
     },
@@ -10881,6 +11121,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy0v",
       "skos:prefLabel": "Edenwald YA Non-Print Media"
     },
@@ -10891,6 +11132,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy0f",
       "skos:prefLabel": "Chatham Square YA Fiction"
     },
@@ -10901,6 +11143,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay",
       "skos:prefLabel": "Eastchester Young Adult"
     },
@@ -10921,6 +11164,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bry",
       "skos:prefLabel": "George Bruce Young Adult"
     },
@@ -10931,6 +11175,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra",
       "skos:prefLabel": "George Bruce Adult"
     },
@@ -10941,6 +11186,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj0y",
       "skos:prefLabel": "Allerton Children's Young Reader"
     },
@@ -10984,10 +11230,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections  Theatre",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1119"
       },
@@ -11015,6 +11261,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chy01",
       "skos:prefLabel": "Chatham Square YA Reference"
     },
@@ -11025,6 +11272,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla0v",
       "skos:prefLabel": "Morningside Heights Non-Print Media"
     },
@@ -11035,16 +11283,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections  Theatre",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1119"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myt32",
       "skos:prefLabel": "Performing Arts Research Collections {u2013} Theatre"
@@ -11056,6 +11304,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla0l",
       "skos:prefLabel": "Morningside Heights World Languages"
     },
@@ -11066,6 +11315,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla0n",
       "skos:prefLabel": "Morningside Heights Non-Fiction"
     },
@@ -11076,9 +11326,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -11096,6 +11343,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka0n",
       "skos:prefLabel": "Great Kills Non-Fiction"
     },
@@ -11106,9 +11354,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Performing Arts--Offsite--Restricted Use",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -11124,9 +11369,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
@@ -11145,6 +11387,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla0f",
       "skos:prefLabel": "Morningside Heights Fiction"
     },
@@ -11175,6 +11418,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj",
       "skos:prefLabel": "Eastchester Children"
     },
@@ -11195,6 +11439,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btzzz",
       "skos:prefLabel": "Battery Park (error code)"
     },
@@ -11232,10 +11477,30 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mai92",
       "skos:prefLabel": "SASB M2 - General Research - Room 315"
+    },
+    {
+      "@id": "nyplLocation:wtj0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wt"
+      },
+      "nypl:actualLocation": "Westchester Square Children's Fiction",
+      "skos:notation": "wtj0f",
+      "skos:prefLabel": "Westchester Square Children's Fiction"
+    },
+    {
+      "@id": "nyplLocation:nsj",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ns"
+      },
+      "nypl:actualLocation": "96th Street Children",
+      "skos:notation": "nsj",
+      "skos:prefLabel": "96th Street Children"
     },
     {
       "@id": "nyplLocation:blyr",
@@ -11244,6 +11509,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blyr",
       "skos:prefLabel": "Bloomingdale Young Adult Reference"
     },
@@ -11287,9 +11553,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg. - Art Division",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mab"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1110"
       },
@@ -11307,9 +11570,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "SASB Art--Offsite--Restricted",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mab"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1110"
       },
@@ -11327,6 +11587,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej01",
       "skos:prefLabel": "Belmont Children's Reference"
     },
@@ -11337,14 +11598,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg - Art Division",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1110"
       },
@@ -11362,6 +11615,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba",
       "skos:prefLabel": "High Bridge Adult"
     },
@@ -11372,6 +11626,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0f",
       "skos:prefLabel": "Dongan Hills Children's Fiction"
     },
@@ -11382,6 +11637,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpy",
       "skos:prefLabel": "Clason's Point Young Adult"
     },
@@ -11392,6 +11648,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwjr",
       "skos:prefLabel": "Fort Washington Children's Reference"
     },
@@ -11402,7 +11659,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Reserve Film and Video Adult Non-Fiction",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "skos:notation": "myarn",
       "skos:prefLabel": "Reserve Film and Video Adult Non-Fiction"
     },
@@ -11423,6 +11680,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka01",
       "skos:prefLabel": "Great Kills Reference"
     },
@@ -11433,6 +11691,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka03",
       "skos:prefLabel": "Great Kills Closed Shelf Reference"
     },
@@ -11453,6 +11712,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhar",
       "skos:prefLabel": "Dongan Hills Adult Reference"
     },
@@ -11463,6 +11723,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clyr",
       "skos:prefLabel": "Morningside Heights Young Adult Reference"
     },
@@ -11483,8 +11744,19 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa",
       "skos:prefLabel": "Clason's Point Adult"
+    },
+    {
+      "@id": "nyplLocation:moj01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mo"
+      },
+      "nypl:actualLocation": "Mosholu Children's Reference",
+      "skos:notation": "moj01",
+      "skos:prefLabel": "Mosholu Children's Reference"
     },
     {
       "@id": "nyplLocation:bej0f",
@@ -11493,6 +11765,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0f",
       "skos:prefLabel": "Belmont Children's Fiction"
     },
@@ -11503,6 +11776,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0a",
       "skos:prefLabel": "Belmont Children's Easy Book"
     },
@@ -11513,6 +11787,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0l",
       "skos:prefLabel": "Belmont Children's World Languages"
     },
@@ -11523,6 +11798,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0n",
       "skos:prefLabel": "Belmont Children's Non-Fiction"
     },
@@ -11533,6 +11809,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0i",
       "skos:prefLabel": "Belmont Children's Picture Book"
     },
@@ -11543,6 +11820,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0h",
       "skos:prefLabel": "Belmont Children's Holiday Book"
     },
@@ -11553,6 +11831,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0v",
       "skos:prefLabel": "Bronx Library Center Children's Non-Print Media"
     },
@@ -11573,6 +11852,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0t",
       "skos:prefLabel": "Belmont Children's Fairy Tale"
     },
@@ -11583,6 +11863,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0v",
       "skos:prefLabel": "Belmont Children's Non-Print Media"
     },
@@ -11593,6 +11874,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0n",
       "skos:prefLabel": "Dongan Hills Children's Non-Fiction"
     },
@@ -11613,6 +11895,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej0y",
       "skos:prefLabel": "Belmont Children's Young Reader"
     },
@@ -11645,9 +11928,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1118"
       },
@@ -11663,9 +11943,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
@@ -11720,6 +11997,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka0v",
       "skos:prefLabel": "Great Kills Non-Print Media"
     },
@@ -11741,9 +12019,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
@@ -11775,6 +12050,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gka0l",
       "skos:prefLabel": "Great Kills World Languages"
     },
@@ -11795,10 +12071,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Music",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1123"
       },
@@ -11817,6 +12093,10 @@
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
       "skos:notation": "myar1",
       "skos:prefLabel": "Performing Arts - Reserve Film and Video - Reference"
@@ -11858,9 +12138,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Preservation Division use only",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:max"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -11895,14 +12172,15 @@
       "skos:prefLabel": "SASB (Children's Center at 42nd St.) - Young Reader Rm 84"
     },
     {
-      "@id": "nyplLocation:eaar",
+      "@id": "nyplLocation:dhj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:dh"
       },
-      "nypl:actualLocation": "Eastchester Adult Reference",
-      "skos:notation": "eaar",
-      "skos:prefLabel": "Eastchester Adult Reference"
+      "nypl:actualLocation": "Dongan Hills Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "dhj0v",
+      "skos:prefLabel": "Dongan Hills Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:tvy01",
@@ -11963,6 +12241,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta0l",
       "skos:prefLabel": "53rd Street World Languages"
     },
@@ -11972,6 +12251,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta0n",
       "skos:prefLabel": "53rd Street Non-Fiction"
     },
@@ -12012,6 +12292,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hb",
       "skos:prefLabel": "High Bridge"
     },
@@ -12021,6 +12302,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta0f",
       "skos:prefLabel": "53rd Street Fiction"
     },
@@ -12031,6 +12313,7 @@
         "@id": "nyplLocation:hg"
       },
       "nypl:actualLocation": "Hamilton Grange",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hg",
       "skos:prefLabel": "Hamilton Grange"
     },
@@ -12041,6 +12324,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hf",
       "skos:prefLabel": "Hamilton Fish Park"
     },
@@ -12051,6 +12335,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hd",
       "skos:prefLabel": "125th Street"
     },
@@ -12100,6 +12385,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta0v",
       "skos:prefLabel": "53rd Street Non-Print Media"
     },
@@ -12114,14 +12400,14 @@
       "skos:prefLabel": "Hamilton Grange YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:fwj0i",
+      "@id": "nyplLocation:ftj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fw"
+        "@id": "nyplLocation:ft"
       },
-      "nypl:actualLocation": "Fort Washington Children's Picture Book",
-      "skos:notation": "fwj0i",
-      "skos:prefLabel": "Fort Washington Children's Picture Book"
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ftj0t",
+      "skos:prefLabel": "53rd Street Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:hgy0l",
@@ -12200,6 +12486,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chzzz",
       "skos:prefLabel": "Chatham Square (error code)"
     },
@@ -12210,6 +12497,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala01",
       "skos:prefLabel": "Allerton Reference"
     },
@@ -12229,6 +12517,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta01",
       "skos:prefLabel": "53rd Street Reference"
     },
@@ -12238,6 +12527,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta03",
       "skos:prefLabel": "53rd Street Closed Shelf Reference"
     },
@@ -12277,6 +12567,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa01",
       "skos:prefLabel": "Edenwald Reference"
     },
@@ -12297,6 +12588,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0t",
       "skos:prefLabel": "Fort Washington Children's Fairy Tale"
     },
@@ -12337,6 +12629,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcar",
       "skos:prefLabel": "Bronx Library Center Adult Reference"
     },
@@ -12367,6 +12660,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy01",
       "skos:prefLabel": "Grand Concourse YA Reference"
     },
@@ -12399,6 +12693,16 @@
       "nypl:actualLocation": "Todt Hill-Westerleigh Non-Print Media",
       "skos:notation": "tha0v",
       "skos:prefLabel": "Todt Hill-Westerleigh Non-Print Media"
+    },
+    {
+      "@id": "nyplLocation:hua0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:hu"
+      },
+      "nypl:actualLocation": "115th Street Fiction",
+      "skos:notation": "hua0f",
+      "skos:prefLabel": "115th Street Fiction"
     },
     {
       "@id": "nyplLocation:muj0i",
@@ -12461,14 +12765,15 @@
       "skos:prefLabel": "Van Cortlandt YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:tha0n",
+      "@id": "nyplLocation:bezzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:th"
+        "@id": "nyplLocation:be"
       },
-      "nypl:actualLocation": "Todt Hill-Westerleigh Non-Fiction",
-      "skos:notation": "tha0n",
-      "skos:prefLabel": "Todt Hill-Westerleigh Non-Fiction"
+      "nypl:actualLocation": "Belmont (error code)",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "bezzz",
+      "skos:prefLabel": "Belmont (error code)"
     },
     {
       "@id": "nyplLocation:tha0l",
@@ -12487,6 +12792,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy0l",
       "skos:prefLabel": "Grand Concourse YA World Languages"
     },
@@ -12497,6 +12803,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy0n",
       "skos:prefLabel": "Grand Concourse YA Non-Fiction"
     },
@@ -12527,6 +12834,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy0f",
       "skos:prefLabel": "Grand Concourse YA Fiction"
     },
@@ -12547,47 +12855,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "NYPL Research Libraries",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -12605,6 +12872,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdy0v",
       "skos:prefLabel": "Grand Concourse YA Non-Print Media"
     },
@@ -12635,31 +12903,9 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfzzz",
       "skos:prefLabel": "Hamilton Fish Park (error code)"
-    },
-    {
-      "@id": "nyplLocation:sce",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:actualLocation": "Schomburg Center - Photographs & Prints",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1118"
-      },
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SP"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "sce",
-      "skos:prefLabel": "Schomburg Center - Photographs & Prints"
     },
     {
       "@id": "nyplLocation:vcy01",
@@ -12698,6 +12944,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bazzz",
       "skos:prefLabel": "Baychester (error code)"
     },
@@ -12712,22 +12959,13 @@
       "skos:prefLabel": "West New Brighton YA Non-Print Media"
     },
     {
-      "@id": "nyplLocation:hlyr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:hl"
-      },
-      "nypl:actualLocation": "Harlem Young Adult Reference",
-      "skos:notation": "hlyr",
-      "skos:prefLabel": "Harlem Young Adult Reference"
-    },
-    {
       "@id": "nyplLocation:bear",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bear",
       "skos:prefLabel": "Belmont Adult Reference"
     },
@@ -12788,6 +13026,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0f",
       "skos:prefLabel": "Chatham Square Children's Fiction"
     },
@@ -12808,6 +13047,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0a",
       "skos:prefLabel": "Chatham Square Children's Easy Book"
     },
@@ -12818,6 +13058,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0n",
       "skos:prefLabel": "Chatham Square Children's Non-Fiction"
     },
@@ -12828,6 +13069,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0l",
       "skos:prefLabel": "Chatham Square Children's World Languages"
     },
@@ -12848,6 +13090,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0i",
       "skos:prefLabel": "Chatham Square Children's Picture Book"
     },
@@ -12858,6 +13101,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0h",
       "skos:prefLabel": "Chatham Square Children's Holiday Book"
     },
@@ -12878,6 +13122,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0v",
       "skos:prefLabel": "Chatham Square Children's Non-Print Media"
     },
@@ -12888,6 +13133,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0t",
       "skos:prefLabel": "Chatham Square Children's Fairy Tale"
     },
@@ -12938,6 +13184,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj0y",
       "skos:prefLabel": "Chatham Square Children's Young Reader"
     },
@@ -13039,34 +13286,34 @@
       },
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:mai"
         },
         {
           "@id": "nyplLocation:map"
         },
         {
           "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maln"
         }
       ],
       "nypl:owner": {
@@ -13074,7 +13321,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mag92",
       "skos:prefLabel": "SASB M2 - Milstein Division - Room 121"
@@ -13120,22 +13367,13 @@
       "skos:prefLabel": "Tompkins Square Children"
     },
     {
-      "@id": "nyplLocation:hfy0f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:hf"
-      },
-      "nypl:actualLocation": "Hamilton Fish Park YA Fiction",
-      "skos:notation": "hfy0f",
-      "skos:prefLabel": "Hamilton Fish Park YA Fiction"
-    },
-    {
       "@id": "nyplLocation:chj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chj01",
       "skos:prefLabel": "Chatham Square Children's Reference"
     },
@@ -13146,6 +13384,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csar",
       "skos:prefLabel": "Columbus Adult Reference"
     },
@@ -13196,6 +13435,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy0f",
       "skos:prefLabel": "125th Street YA Fiction"
     },
@@ -13226,6 +13466,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy0n",
       "skos:prefLabel": "125th Street YA Non-Fiction"
     },
@@ -13236,6 +13477,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy0l",
       "skos:prefLabel": "125th Street YA World Languages"
     },
@@ -13249,14 +13491,14 @@
       "skos:prefLabel": "Mosholu Adult Learning Center"
     },
     {
-      "@id": "nyplLocation:wha01",
+      "@id": "nyplLocation:moa0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
+        "@id": "nyplLocation:mo"
       },
-      "nypl:actualLocation": "Washington Heights Reference",
-      "skos:notation": "wha01",
-      "skos:prefLabel": "Washington Heights Reference"
+      "nypl:actualLocation": "Mosholu Non-Print Media",
+      "skos:notation": "moa0v",
+      "skos:prefLabel": "Mosholu Non-Print Media"
     },
     {
       "@id": "nyplLocation:wha03",
@@ -13275,6 +13517,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy0v",
       "skos:prefLabel": "125th Street YA Non-Print Media"
     },
@@ -13295,6 +13538,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey01",
       "skos:prefLabel": "Belmont YA Reference"
     },
@@ -13309,16 +13553,6 @@
       "skos:prefLabel": "Hunt's Point (error code)"
     },
     {
-      "@id": "nyplLocation:whj0a",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
-      },
-      "nypl:actualLocation": "Washington Heights Children's Easy Book",
-      "skos:notation": "whj0a",
-      "skos:prefLabel": "Washington Heights Children's Easy Book"
-    },
-    {
       "@id": "nyplLocation:yvzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -13329,12 +13563,23 @@
       "skos:prefLabel": "Yorkville (error code)"
     },
     {
+      "@id": "nyplLocation:mua0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mu"
+      },
+      "nypl:actualLocation": "Muhlenberg Fiction",
+      "skos:notation": "mua0f",
+      "skos:prefLabel": "Muhlenberg Fiction"
+    },
+    {
       "@id": "nyplLocation:gcy01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy01",
       "skos:prefLabel": "Grand Central YA Reference"
     },
@@ -13353,7 +13598,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mai87",
       "skos:prefLabel": "SASB - Periodicals and Microforms Rm 100"
@@ -13367,16 +13612,6 @@
       "nypl:actualLocation": "Muhlenberg Young Adult",
       "skos:notation": "muy",
       "skos:prefLabel": "Muhlenberg Young Adult"
-    },
-    {
-      "@id": "nyplLocation:gk",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:gk"
-      },
-      "nypl:actualLocation": "Great Kills",
-      "skos:notation": "gk",
-      "skos:prefLabel": "Great Kills"
     },
     {
       "@id": "nyplLocation:ssa0v",
@@ -13403,7 +13638,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mai83",
       "skos:prefLabel": "SASB - Periodicals and Microforms Rm 100"
@@ -13423,7 +13658,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mai82",
       "skos:prefLabel": "SASB M1 - Periodicals and Microforms Rm 100"
@@ -13445,6 +13680,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Adult"
     },
@@ -13459,14 +13695,14 @@
       "skos:prefLabel": "Washington Heights Non-Fiction"
     },
     {
-      "@id": "nyplLocation:pry0f",
+      "@id": "nyplLocation:tsj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:ts"
       },
-      "nypl:actualLocation": "Port Richmond YA Fiction",
-      "skos:notation": "pry0f",
-      "skos:prefLabel": "Port Richmond YA Fiction"
+      "nypl:actualLocation": "Tompkins Square Children's Fairy Tale",
+      "skos:notation": "tsj0t",
+      "skos:prefLabel": "Tompkins Square Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:muj",
@@ -13485,6 +13721,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy01",
       "skos:prefLabel": "125th Street YA Reference"
     },
@@ -13505,6 +13742,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Young Adult"
     },
@@ -13574,6 +13812,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy0v",
       "skos:prefLabel": "Grand Central YA Non-Print Media"
     },
@@ -13584,6 +13823,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdzzz",
       "skos:prefLabel": "Grand Concourse (error code)"
     },
@@ -13594,6 +13834,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy0l",
       "skos:prefLabel": "Grand Central YA World Languages"
     },
@@ -13604,6 +13845,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy0n",
       "skos:prefLabel": "Grand Central YA Non-Fiction"
     },
@@ -13614,6 +13856,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhjr",
       "skos:prefLabel": "Dongan Hills Children's Reference"
     },
@@ -13624,6 +13867,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy0f",
       "skos:prefLabel": "Grand Central YA Fiction"
     },
@@ -13634,10 +13878,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections  Dance",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
@@ -13705,6 +13949,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba0f",
       "skos:prefLabel": "High Bridge Fiction"
     },
@@ -13725,6 +13970,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0v",
       "skos:prefLabel": "Grand Concourse Children's Non-Print Media"
     },
@@ -13745,6 +13991,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0t",
       "skos:prefLabel": "Grand Concourse Children's Fairy Tale"
     },
@@ -13755,6 +14002,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bry0f",
       "skos:prefLabel": "George Bruce YA Fiction"
     },
@@ -13775,6 +14023,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj01",
       "skos:prefLabel": "Columbus Children's Reference"
     },
@@ -13805,6 +14054,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bry0n",
       "skos:prefLabel": "George Bruce YA Non-Fiction"
     },
@@ -13815,6 +14065,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0y",
       "skos:prefLabel": "Grand Concourse Children's Young Reader"
     },
@@ -13825,6 +14076,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bry0l",
       "skos:prefLabel": "George Bruce YA World Languages"
     },
@@ -13835,6 +14087,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0f",
       "skos:prefLabel": "Grand Concourse Children's Fiction"
     },
@@ -13843,9 +14096,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
@@ -13877,7 +14127,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "magg2",
       "skos:prefLabel": "SASB - Milstein Division - Mezzanine"
@@ -13914,6 +14164,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0a",
       "skos:prefLabel": "Grand Concourse Children's Easy Book"
     },
@@ -13926,10 +14177,10 @@
       "nypl:actualLocation": "Schwarzman Building - Milstein Division Reference Rm 121",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mag"
         }
       ],
       "nypl:owner": {
@@ -13948,9 +14199,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
       },
@@ -13968,6 +14216,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0n",
       "skos:prefLabel": "Grand Concourse Children's Non-Fiction"
     },
@@ -13988,6 +14237,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0l",
       "skos:prefLabel": "Grand Concourse Children's World Languages"
     },
@@ -13998,6 +14248,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0i",
       "skos:prefLabel": "Grand Concourse Children's Picture Book"
     },
@@ -14008,18 +14259,19 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj0h",
       "skos:prefLabel": "Grand Concourse Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:gkj0n",
+      "@id": "nyplLocation:hlyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gk"
+        "@id": "nyplLocation:hl"
       },
-      "nypl:actualLocation": "Great Kills Children's Non-Fiction",
-      "skos:notation": "gkj0n",
-      "skos:prefLabel": "Great Kills Children's Non-Fiction"
+      "nypl:actualLocation": "Harlem Young Adult Reference",
+      "skos:notation": "hlyr",
+      "skos:prefLabel": "Harlem Young Adult Reference"
     },
     {
       "@id": "nyplLocation:ndzzz",
@@ -14057,6 +14309,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0f",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Fiction"
     },
@@ -14067,6 +14320,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0y",
       "skos:prefLabel": "Columbus Children's Young Reader"
     },
@@ -14077,6 +14331,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0a",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Easy Book"
     },
@@ -14087,6 +14342,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdj01",
       "skos:prefLabel": "Grand Concourse Children's Reference"
     },
@@ -14097,6 +14353,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0l",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's World Languages"
     },
@@ -14107,6 +14364,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0n",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Fiction"
     },
@@ -14117,6 +14375,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0i",
       "skos:prefLabel": "Great Kills Children's Picture Book"
     },
@@ -14127,6 +14386,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0v",
       "skos:prefLabel": "Columbus Children's Non-Print Media"
     },
@@ -14137,6 +14397,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0i",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Picture Book"
     },
@@ -14147,6 +14408,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0t",
       "skos:prefLabel": "Columbus Children's Fairy Tale"
     },
@@ -14157,6 +14419,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0t",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Fairy Tale"
     },
@@ -14167,18 +14430,20 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0f",
       "skos:prefLabel": "Great Kills Children's Fiction"
     },
     {
-      "@id": "nyplLocation:bry01",
+      "@id": "nyplLocation:csj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:br"
+        "@id": "nyplLocation:cs"
       },
-      "nypl:actualLocation": "George Bruce YA Reference",
-      "skos:notation": "bry01",
-      "skos:prefLabel": "George Bruce YA Reference"
+      "nypl:actualLocation": "Columbus Children's Holiday Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "csj0h",
+      "skos:prefLabel": "Columbus Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:csj0i",
@@ -14187,6 +14452,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0i",
       "skos:prefLabel": "Columbus Children's Picture Book"
     },
@@ -14197,6 +14463,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0n",
       "skos:prefLabel": "Columbus Children's Non-Fiction"
     },
@@ -14207,18 +14474,19 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0l",
       "skos:prefLabel": "Columbus Children's World Languages"
     },
     {
-      "@id": "nyplLocation:hba0v",
+      "@id": "nyplLocation:mhj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hb"
+        "@id": "nyplLocation:mh"
       },
-      "nypl:actualLocation": "High Bridge Non-Print Media",
-      "skos:notation": "hba0v",
-      "skos:prefLabel": "High Bridge Non-Print Media"
+      "nypl:actualLocation": "Mott Haven Children's Non-Print Media",
+      "skos:notation": "mhj0v",
+      "skos:prefLabel": "Mott Haven Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:csj0f",
@@ -14227,6 +14495,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0f",
       "skos:prefLabel": "Columbus Children's Fiction"
     },
@@ -14241,14 +14510,14 @@
       "skos:prefLabel": "Westchester Square YA Reference"
     },
     {
-      "@id": "nyplLocation:hby0n",
+      "@id": "nyplLocation:tgjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hb"
+        "@id": "nyplLocation:tg"
       },
-      "nypl:actualLocation": "High Bridge YA Non-Fiction",
-      "skos:notation": "hby0n",
-      "skos:prefLabel": "High Bridge YA Non-Fiction"
+      "nypl:actualLocation": "Throg's Neck Children's Reference",
+      "skos:notation": "tgjr",
+      "skos:prefLabel": "Throg's Neck Children's Reference"
     },
     {
       "@id": "nyplLocation:wbar",
@@ -14277,6 +14546,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0a",
       "skos:prefLabel": "Great Kills Children's Easy Book"
     },
@@ -14287,6 +14557,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyar",
       "skos:prefLabel": "Spuyten Duyvil Adult Reference"
     },
@@ -14367,6 +14638,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxjr",
       "skos:prefLabel": "Francis Martin Children's Reference"
     },
@@ -14427,9 +14699,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -14451,25 +14720,14 @@
       "skos:prefLabel": "67th Street Non-Fiction"
     },
     {
-      "@id": "nyplLocation:myt",
+      "@id": "nyplLocation:wha",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
+        "@id": "nyplLocation:wh"
       },
-      "nypl:actualLocation": "Performing Arts Research Collections - Theatre",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:locationType": "Research",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1119"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "skos:notation": "myt",
-      "skos:prefLabel": "Performing Arts Research Collections - Theatre"
+      "nypl:actualLocation": "Washington Heights Adult",
+      "skos:notation": "wha",
+      "skos:prefLabel": "Washington Heights Adult"
     },
     {
       "@id": "nyplLocation:rtj",
@@ -14512,14 +14770,14 @@
       "skos:prefLabel": "Inwood"
     },
     {
-      "@id": "nyplLocation:moa0v",
+      "@id": "nyplLocation:wha01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mo"
+        "@id": "nyplLocation:wh"
       },
-      "nypl:actualLocation": "Mosholu Non-Print Media",
-      "skos:notation": "moa0v",
-      "skos:prefLabel": "Mosholu Non-Print Media"
+      "nypl:actualLocation": "Washington Heights Reference",
+      "skos:notation": "wha01",
+      "skos:prefLabel": "Washington Heights Reference"
     },
     {
       "@id": "nyplLocation:hlar",
@@ -14558,6 +14816,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey0v",
       "skos:prefLabel": "Belmont YA Non-Print Media"
     },
@@ -14598,9 +14857,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Performing Arts--Offsite--Restricted Use",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -14618,6 +14874,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly0v",
       "skos:prefLabel": "Allerton YA Non-Print Media"
     },
@@ -14638,6 +14895,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly0f",
       "skos:prefLabel": "Allerton YA Fiction"
     },
@@ -14658,6 +14916,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly0n",
       "skos:prefLabel": "Allerton YA Non-Fiction"
     },
@@ -14668,7 +14927,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Closed Shelf Reference Recorded Media",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -14682,8 +14941,19 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly0l",
       "skos:prefLabel": "Allerton YA World Languages"
+    },
+    {
+      "@id": "nyplLocation:hty0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ht"
+      },
+      "nypl:actualLocation": "Countee Cullen YA Non-Print Media",
+      "skos:notation": "hty0v",
+      "skos:prefLabel": "Countee Cullen YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:bey0n",
@@ -14692,6 +14962,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey0n",
       "skos:prefLabel": "Belmont YA Non-Fiction"
     },
@@ -14701,6 +14972,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty0f",
       "skos:prefLabel": "53rd Street YA Fiction"
     },
@@ -14720,6 +14992,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty0l",
       "skos:prefLabel": "53rd Street YA World Languages"
     },
@@ -14729,6 +15002,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty0n",
       "skos:prefLabel": "53rd Street YA Non-Fiction"
     },
@@ -14739,6 +15013,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey0l",
       "skos:prefLabel": "Belmont YA World Languages"
     },
@@ -14799,6 +15074,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly01",
       "skos:prefLabel": "Allerton YA Reference"
     },
@@ -14819,9 +15095,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Pforzheimer Collection Rm 319",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:maq"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1102"
       },
@@ -14896,14 +15174,15 @@
       "skos:prefLabel": "St. George YA Fiction"
     },
     {
-      "@id": "nyplLocation:lma",
+      "@id": "nyplLocation:cly0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:lm"
+        "@id": "nyplLocation:cl"
       },
-      "nypl:actualLocation": "New Amsterdam Adult",
-      "skos:notation": "lma",
-      "skos:prefLabel": "New Amsterdam Adult"
+      "nypl:actualLocation": "Morningside Heights YA Non-Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cly0n",
+      "skos:prefLabel": "Morningside Heights YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:sgy0l",
@@ -14922,6 +15201,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fear",
       "skos:prefLabel": "58th Street Adult Reference"
     },
@@ -14932,6 +15212,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj",
       "skos:prefLabel": "Bloomingdale Children"
     },
@@ -14956,16 +15237,6 @@
       "skos:prefLabel": "Sedgwick Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:wlyr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
-      },
-      "nypl:actualLocation": "Woodlawn Heights Young Adult Reference",
-      "skos:notation": "wlyr",
-      "skos:prefLabel": "Woodlawn Heights Young Adult Reference"
-    },
-    {
       "@id": "nyplLocation:sdj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -14982,6 +15253,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bla",
       "skos:prefLabel": "Bloomingdale Adult"
     },
@@ -14996,22 +15268,13 @@
       "skos:prefLabel": "Muhlenberg Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:tgj0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
-      },
-      "nypl:actualLocation": "Throg's Neck Children's Non-Fiction",
-      "skos:notation": "tgj0n",
-      "skos:prefLabel": "Throg's Neck Children's Non-Fiction"
-    },
-    {
       "@id": "nyplLocation:bly",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly",
       "skos:prefLabel": "Bloomingdale Young Adult"
     },
@@ -15021,6 +15284,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty01",
       "skos:prefLabel": "53rd Street YA Reference"
     },
@@ -15045,12 +15309,24 @@
       "skos:prefLabel": "Schomburg Center - Moving Image & Recorded Sound"
     },
     {
+      "@id": "nyplLocation:chyr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ch"
+      },
+      "nypl:actualLocation": "Chatham Square Young Adult Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "chyr",
+      "skos:prefLabel": "Chatham Square Young Adult Reference"
+    },
+    {
       "@id": "nyplLocation:char",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "char",
       "skos:prefLabel": "Chatham Square Adult Reference"
     },
@@ -15111,6 +15387,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa",
       "skos:prefLabel": "Hamilton Fish Park Adult"
     },
@@ -15121,6 +15398,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfj",
       "skos:prefLabel": "Hamilton Fish Park Children"
     },
@@ -15161,6 +15439,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa0f",
       "skos:prefLabel": "Fort Washington Fiction"
     },
@@ -15201,6 +15480,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa0l",
       "skos:prefLabel": "Fort Washington World Languages"
     },
@@ -15221,6 +15501,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa0n",
       "skos:prefLabel": "Fort Washington Non-Fiction"
     },
@@ -15271,6 +15552,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agjr",
       "skos:prefLabel": "Aguilar Children's Reference"
     },
@@ -15281,6 +15563,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa0v",
       "skos:prefLabel": "Fort Washington Non-Print Media"
     },
@@ -15290,6 +15573,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:fw"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa0w",
       "skos:prefLabel": "Fort Washington Adult Learning Center"
     },
@@ -15330,9 +15614,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mar"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1108"
       },
@@ -15370,10 +15651,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Theatre - Reference",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1119"
       },
@@ -15404,9 +15685,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -15454,6 +15732,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa01",
       "skos:prefLabel": "Fort Washington Reference"
     },
@@ -15464,6 +15743,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa03",
       "skos:prefLabel": "Fort Washington Closed Shelf Reference"
     },
@@ -15495,7 +15775,7 @@
       },
       "nypl:actualLocation": "Schwarzman Building - Dewitt Wallace Room 108",
       "nypl:deliverableTo": {
-        "@id": "nyplLocation:mak?"
+        "@id": "nyplLocation:mak"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
@@ -15524,6 +15804,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky0v",
       "skos:prefLabel": "Great Kills YA Non-Print Media"
     },
@@ -15604,6 +15885,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky0f",
       "skos:prefLabel": "Great Kills YA Fiction"
     },
@@ -15624,6 +15906,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky0l",
       "skos:prefLabel": "Great Kills YA World Languages"
     },
@@ -15634,6 +15917,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky0n",
       "skos:prefLabel": "Great Kills YA Non-Fiction"
     },
@@ -15644,18 +15928,19 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbar",
       "skos:prefLabel": "High Bridge Adult Reference"
     },
     {
-      "@id": "nyplLocation:pry0l",
+      "@id": "nyplLocation:jpj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:jp"
       },
-      "nypl:actualLocation": "Port Richmond YA World Languages",
-      "skos:notation": "pry0l",
-      "skos:prefLabel": "Port Richmond YA World Languages"
+      "nypl:actualLocation": "Jerome Park Children's Young Reader",
+      "skos:notation": "jpj0y",
+      "skos:prefLabel": "Jerome Park Children's Young Reader"
     },
     {
       "@id": "nyplLocation:wla0l",
@@ -15714,6 +15999,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cszzz",
       "skos:prefLabel": "Columbus (error code)"
     },
@@ -15724,6 +16010,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alyr",
       "skos:prefLabel": "Allerton Young Adult Reference"
     },
@@ -15754,6 +16041,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gky01",
       "skos:prefLabel": "Great Kills YA Reference"
     },
@@ -15766,6 +16054,27 @@
       "nypl:actualLocation": "Jerome Park Children's Reference",
       "skos:notation": "jpj01",
       "skos:prefLabel": "Jerome Park Children's Reference"
+    },
+    {
+      "@id": "nyplLocation:ciyr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ci"
+      },
+      "nypl:actualLocation": "City Island Young Adult Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ciyr",
+      "skos:prefLabel": "City Island Young Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:pry0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:pr"
+      },
+      "nypl:actualLocation": "Port Richmond YA Fiction",
+      "skos:notation": "pry0f",
+      "skos:prefLabel": "Port Richmond YA Fiction"
     },
     {
       "@id": "nyplLocation:tva0l",
@@ -15814,9 +16123,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -15834,10 +16140,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -15925,6 +16231,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwzzz",
       "skos:prefLabel": "Fort Washington (error code)"
     },
@@ -16025,6 +16332,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bay0f",
       "skos:prefLabel": "Baychester YA Fiction"
     },
@@ -16064,6 +16372,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fta",
       "skos:prefLabel": "53rd Street Adult"
     },
@@ -16074,6 +16383,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bay0n",
       "skos:prefLabel": "Baychester YA Non-Fiction"
     },
@@ -16084,6 +16394,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bay0l",
       "skos:prefLabel": "Baychester YA World Languages"
     },
@@ -16114,6 +16425,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj",
       "skos:prefLabel": "High Bridge Children"
     },
@@ -16134,6 +16446,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bay0v",
       "skos:prefLabel": "Baychester YA Non-Print Media"
     },
@@ -16193,6 +16506,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj",
       "skos:prefLabel": "53rd Street Children"
     },
@@ -16273,6 +16587,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewjr",
       "skos:prefLabel": "Edenwald Children's Reference"
     },
@@ -16300,14 +16615,15 @@
       "skos:prefLabel": "67th Street Young Adult"
     },
     {
-      "@id": "nyplLocation:bay01",
+      "@id": "nyplLocation:clzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ba"
+        "@id": "nyplLocation:cl"
       },
-      "nypl:actualLocation": "Baychester YA Reference",
-      "skos:notation": "bay01",
-      "skos:prefLabel": "Baychester YA Reference"
+      "nypl:actualLocation": "Morningside Heights (error code)",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "clzzz",
+      "skos:prefLabel": "Morningside Heights (error code)"
     },
     {
       "@id": "nyplLocation:lbj01",
@@ -16460,14 +16776,14 @@
       "skos:prefLabel": "Hudson Park Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:wtj0f",
+      "@id": "nyplLocation:yvjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:yv"
       },
-      "nypl:actualLocation": "Westchester Square Children's Fiction",
-      "skos:notation": "wtj0f",
-      "skos:prefLabel": "Westchester Square Children's Fiction"
+      "nypl:actualLocation": "Yorkville Children's Reference",
+      "skos:notation": "yvjr",
+      "skos:prefLabel": "Yorkville Children's Reference"
     },
     {
       "@id": "nyplLocation:hpj0v",
@@ -16506,6 +16822,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epjr",
       "skos:prefLabel": "Epiphany Children's Reference"
     },
@@ -16576,18 +16893,19 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkjr",
       "skos:prefLabel": "Great Kills Children's Reference"
     },
     {
-      "@id": "nyplLocation:otj0v",
+      "@id": "nyplLocation:sea0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:se"
       },
-      "nypl:actualLocation": "Ottendorfer Children's Non-Print Media",
-      "skos:notation": "otj0v",
-      "skos:prefLabel": "Ottendorfer Children's Non-Print Media"
+      "nypl:actualLocation": "Seward Park Center for Reading & Writing",
+      "skos:notation": "sea0w",
+      "skos:prefLabel": "Seward Park Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:otj0t",
@@ -16716,6 +17034,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0y",
       "skos:prefLabel": "Bloomingdale Children's Young Reader"
     },
@@ -16736,6 +17055,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dh",
       "skos:prefLabel": "Dongan Hills"
     },
@@ -16775,6 +17095,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxar",
       "skos:prefLabel": "Francis Martin Adult Reference"
     },
@@ -16795,8 +17116,20 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dy",
       "skos:prefLabel": "Spuyten Duyvil"
+    },
+    {
+      "@id": "nyplLocation:alj0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:al"
+      },
+      "nypl:actualLocation": "Allerton Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "alj0v",
+      "skos:prefLabel": "Allerton Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:moy01",
@@ -16815,6 +17148,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0l",
       "skos:prefLabel": "Baychester Children's World Languages"
     },
@@ -16845,6 +17179,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gdar",
       "skos:prefLabel": "Grand Concourse Adult Reference"
     },
@@ -16922,16 +17257,6 @@
       "skos:prefLabel": "Morrisania Young Adult Reference"
     },
     {
-      "@id": "nyplLocation:tsa0w",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
-      },
-      "nypl:actualLocation": "Tompkins Square Center for Reading & Writing",
-      "skos:notation": "tsa0w",
-      "skos:prefLabel": "Tompkins Square Center for Reading & Writing"
-    },
-    {
       "@id": "nyplLocation:mas",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -16958,6 +17283,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj0y",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Young Reader"
     },
@@ -16968,6 +17294,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj0f",
       "skos:prefLabel": "Baychester Children's Fiction"
     },
@@ -16990,7 +17317,22 @@
       "nypl:actualLocation": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mai"
         },
         {
           "@id": "nyplLocation:mala"
@@ -16999,31 +17341,16 @@
           "@id": "nyplLocation:myr"
         },
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:sc"
+        },
+        {
+          "@id": "nyplLocation:mal"
         },
         {
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:slr"
@@ -17050,6 +17377,17 @@
       "skos:prefLabel": "Melrose Children"
     },
     {
+      "@id": "nyplLocation:fxa03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:fx"
+      },
+      "nypl:actualLocation": "Francis Martin Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fxa03",
+      "skos:prefLabel": "Francis Martin Closed Shelf Reference"
+    },
+    {
       "@id": "nyplLocation:hua",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -17066,6 +17404,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bayr",
       "skos:prefLabel": "Baychester Young Adult Reference"
     },
@@ -17149,6 +17488,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bca",
       "skos:prefLabel": "Bronx Library Center Adult"
     },
@@ -17169,9 +17509,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "Schwarzman Building - Periodicals and Microforms Rm 100",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mai"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -17180,7 +17522,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mai",
       "skos:prefLabel": "SASB - Periodicals and Microforms Rm 100"
@@ -17212,6 +17554,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcy",
       "skos:prefLabel": "Bronx Library Center Young Adult"
     },
@@ -17292,6 +17635,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0a",
       "skos:prefLabel": "Eastchester Children's Easy Book"
     },
@@ -17325,6 +17669,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agzzz",
       "skos:prefLabel": "Aguilar (error code)"
     },
@@ -17334,6 +17679,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:gc"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca0w",
       "skos:prefLabel": "Grand Central Adult Learning Center"
     },
@@ -17344,6 +17690,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca0v",
       "skos:prefLabel": "Grand Central Non-Print Media"
     },
@@ -17352,9 +17699,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mas"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
@@ -17365,16 +17709,6 @@
       },
       "skos:notation": "rcms2",
       "skos:prefLabel": "OFFSITE - Request in Advance for use at Schwarzman Bldg -"
-    },
-    {
-      "@id": "nyplLocation:sbyr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sb"
-      },
-      "nypl:actualLocation": "South Beach Young Adult Reference",
-      "skos:notation": "sbyr",
-      "skos:prefLabel": "South Beach Young Adult Reference"
     },
     {
       "@id": "nyplLocation:hsy01",
@@ -17401,7 +17735,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "malv2",
       "skos:prefLabel": "SASB - General Research - Public Catalog Room 315"
@@ -17413,6 +17747,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca0f",
       "skos:prefLabel": "Grand Central Fiction"
     },
@@ -17423,6 +17758,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca0l",
       "skos:prefLabel": "Grand Central World Languages"
     },
@@ -17433,6 +17769,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca0n",
       "skos:prefLabel": "Grand Central Non-Fiction"
     },
@@ -17453,6 +17790,11 @@
         "@id": "nyplLocation:ls"
       },
       "nypl:actualLocation": "Library Services Center - Cataloging",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:lsbb2"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NC"
       },
@@ -17466,6 +17808,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala0n",
       "skos:prefLabel": "Allerton Non-Fiction"
     },
@@ -17486,6 +17829,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala0l",
       "skos:prefLabel": "Allerton World Languages"
     },
@@ -17496,7 +17840,7 @@
         "@id": "nyplLocation:ri"
       },
       "nypl:actualLocation": "Roosevelt Island Young Adult Reference",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "skos:notation": "riyr",
       "skos:prefLabel": "Roosevelt Island Young Adult Reference"
     },
@@ -17507,6 +17851,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa01",
       "skos:prefLabel": "Eastchester Reference"
     },
@@ -17517,6 +17862,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa03",
       "skos:prefLabel": "Eastchester Closed Shelf Reference"
     },
@@ -17527,10 +17873,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -17558,6 +17904,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala0v",
       "skos:prefLabel": "Allerton Non-Print Media"
     },
@@ -17568,6 +17915,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij01",
       "skos:prefLabel": "City Island Children's Reference"
     },
@@ -17588,6 +17936,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca01",
       "skos:prefLabel": "Grand Central Reference"
     },
@@ -17598,6 +17947,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca03",
       "skos:prefLabel": "Grand Central Closed Shelf Reference"
     },
@@ -17628,7 +17978,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Reserve Film and Video Young Adult",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "skos:notation": "myyrv",
       "skos:prefLabel": "Reserve Film and Video Young Adult"
     },
@@ -17709,6 +18059,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcar",
       "skos:prefLabel": "Grand Central Adult Reference"
     },
@@ -17719,6 +18070,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0l",
       "skos:prefLabel": "City Island Children's World Languages"
     },
@@ -17729,6 +18081,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0n",
       "skos:prefLabel": "City Island Children's Non-Fiction"
     },
@@ -17739,6 +18092,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0h",
       "skos:prefLabel": "City Island Children's Holiday Book"
     },
@@ -17749,6 +18103,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0i",
       "skos:prefLabel": "City Island Children's Picture Book"
     },
@@ -17759,6 +18114,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0f",
       "skos:prefLabel": "City Island Children's Fiction"
     },
@@ -17769,6 +18125,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa0v",
       "skos:prefLabel": "Eastchester Non-Print Media"
     },
@@ -17779,6 +18136,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0a",
       "skos:prefLabel": "City Island Children's Easy Book"
     },
@@ -17789,6 +18147,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa0l",
       "skos:prefLabel": "Eastchester World Languages"
     },
@@ -17799,6 +18158,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa0n",
       "skos:prefLabel": "Eastchester Non-Fiction"
     },
@@ -17809,6 +18169,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0y",
       "skos:prefLabel": "City Island Children's Young Reader"
     },
@@ -17819,6 +18180,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0t",
       "skos:prefLabel": "City Island Children's Fairy Tale"
     },
@@ -17829,6 +18191,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala03",
       "skos:prefLabel": "Allerton Closed Shelf Reference"
     },
@@ -17839,6 +18202,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij0v",
       "skos:prefLabel": "City Island Children's Non-Print Media"
     },
@@ -17849,42 +18213,19 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa0f",
       "skos:prefLabel": "Eastchester Fiction"
     },
     {
-      "@id": "nyplLocation:mma33",
+      "@id": "nyplLocation:wka0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mm"
+        "@id": "nyplLocation:wk"
       },
-      "nypl:actualLocation": "Mid-Manhattan Closed Shelf Reference Third Floor",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1500"
-      },
-      "skos:notation": "mma33",
-      "skos:prefLabel": "Mid-Manhattan Closed Shelf Reference Third Floor"
-    },
-    {
-      "@id": "nyplLocation:myh42",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
-      },
-      "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:locationType": "Research",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1002"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "myh42",
-      "skos:prefLabel": "OFFSITE Rose - Request in advance for use at Performing Arts"
+      "nypl:actualLocation": "Wakefield Center for Reading & Writing",
+      "skos:notation": "wka0w",
+      "skos:prefLabel": "Wakefield Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:fej0y",
@@ -17893,6 +18234,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0y",
       "skos:prefLabel": "58th Street Children's Young Reader"
     },
@@ -17903,38 +18245,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -17952,6 +18262,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0t",
       "skos:prefLabel": "58th Street Children's Fairy Tale"
     },
@@ -17962,6 +18273,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0v",
       "skos:prefLabel": "58th Street Children's Non-Print Media"
     },
@@ -17972,6 +18284,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0i",
       "skos:prefLabel": "58th Street Children's Picture Book"
     },
@@ -17982,6 +18295,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0h",
       "skos:prefLabel": "58th Street Children's Holiday Book"
     },
@@ -17992,6 +18306,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0l",
       "skos:prefLabel": "58th Street Children's World Languages"
     },
@@ -18002,6 +18317,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0n",
       "skos:prefLabel": "58th Street Children's Non-Fiction"
     },
@@ -18012,6 +18328,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0a",
       "skos:prefLabel": "58th Street Children's Easy Book"
     },
@@ -18022,6 +18339,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej0f",
       "skos:prefLabel": "58th Street Children's Fiction"
     },
@@ -18032,7 +18350,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating YA Non-Print Media",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18046,6 +18364,7 @@
         "@id": "nyplLocation:ed"
       },
       "nypl:actualLocation": "LSC Educator Collection",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eduls",
       "skos:prefLabel": "LSC Educator Collection"
     },
@@ -18058,16 +18377,6 @@
       "nypl:actualLocation": "Kips Bay Adult",
       "skos:notation": "kpa",
       "skos:prefLabel": "Kips Bay Adult"
-    },
-    {
-      "@id": "nyplLocation:mua0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
-      },
-      "nypl:actualLocation": "Muhlenberg World Languages",
-      "skos:notation": "mua0l",
-      "skos:prefLabel": "Muhlenberg World Languages"
     },
     {
       "@id": "nyplLocation:kpj",
@@ -18090,23 +18399,20 @@
       "skos:prefLabel": "Yorkville"
     },
     {
-      "@id": "nyplLocation:gcj0n",
+      "@id": "nyplLocation:pk",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gc"
+        "@id": "nyplLocation:pk"
       },
-      "nypl:actualLocation": "Grand Central Children's Non-Fiction",
-      "skos:notation": "gcj0n",
-      "skos:prefLabel": "Grand Central Children's Non-Fiction"
+      "nypl:actualLocation": "Parkchester",
+      "skos:notation": "pk",
+      "skos:prefLabel": "Parkchester"
     },
     {
       "@id": "nyplLocation:rccf9",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1114"
@@ -18135,7 +18441,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts - Reserve Film and Video",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18153,14 +18459,25 @@
       "skos:prefLabel": "Mosholu Children's Reference"
     },
     {
-      "@id": "nyplLocation:wha",
+      "@id": "nyplLocation:myt",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
+        "@id": "nyplLocation:my"
       },
-      "nypl:actualLocation": "Washington Heights Adult",
-      "skos:notation": "wha",
-      "skos:prefLabel": "Washington Heights Adult"
+      "nypl:actualLocation": "Performing Arts Research Collections - Theatre",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1119"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "myt",
+      "skos:prefLabel": "Performing Arts Research Collections - Theatre"
     },
     {
       "@id": "nyplLocation:mpar",
@@ -18179,10 +18496,11 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Branch",
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18191,7 +18509,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myr",
       "skos:prefLabel": "Performing Arts Research Collections"
@@ -18213,6 +18531,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej01",
       "skos:prefLabel": "58th Street Children's Reference"
     },
@@ -18233,7 +18552,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Young Adult",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18247,10 +18566,11 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - TOFT",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1120"
       },
@@ -18271,16 +18591,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Dance",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myd",
       "skos:prefLabel": "Performing Arts Research Collections - Dance"
@@ -18302,7 +18622,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts - Adult",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18316,6 +18636,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey0f",
       "skos:prefLabel": "Belmont YA Fiction"
     },
@@ -18336,16 +18657,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Music",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1123"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mym",
       "skos:prefLabel": "Performing Arts Research Collections - Music"
@@ -18357,7 +18678,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Children",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18371,16 +18692,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Recorded Sound",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1124"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myh",
       "skos:prefLabel": "Performing Arts Research Collections - Recorded Sound"
@@ -18402,6 +18723,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj01",
       "skos:prefLabel": "Bloomingdale Children's Reference"
     },
@@ -18422,6 +18744,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctar",
       "skos:prefLabel": "Castle Hill Adult Reference"
     },
@@ -18442,6 +18765,7 @@
         "@id": "nyplLocation:ed"
       },
       "nypl:actualLocation": "LSC Educator Collection",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ed",
       "skos:prefLabel": "LSC Educator Collection"
     },
@@ -18462,6 +18786,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ea",
       "skos:prefLabel": "Eastchester"
     },
@@ -18492,6 +18817,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ew",
       "skos:prefLabel": "Edenwald"
     },
@@ -18502,6 +18828,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ep",
       "skos:prefLabel": "Epiphany"
     },
@@ -18532,10 +18859,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18583,9 +18910,11 @@
         "@id": "nyplLocation:sc"
       },
       "nypl:actualLocation": "Schomburg Center",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:sc"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
       },
@@ -18594,7 +18923,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "sc",
       "skos:prefLabel": "Schomburg Center"
@@ -18614,20 +18943,10 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "slr22",
       "skos:prefLabel": "SIBL - B. Altman Desk"
-    },
-    {
-      "@id": "nyplLocation:hpy",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:hp"
-      },
-      "nypl:actualLocation": "Hudson Park Young Adult",
-      "skos:notation": "hpy",
-      "skos:prefLabel": "Hudson Park Young Adult"
     },
     {
       "@id": "nyplLocation:nsa0v",
@@ -18646,6 +18965,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0v",
       "skos:prefLabel": "Bloomingdale Children's Non-Print Media"
     },
@@ -18656,6 +18976,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0t",
       "skos:prefLabel": "Bloomingdale Children's Fairy Tale"
     },
@@ -18686,6 +19007,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0a",
       "skos:prefLabel": "Bloomingdale Children's Easy Book"
     },
@@ -18696,6 +19018,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0f",
       "skos:prefLabel": "Bloomingdale Children's Fiction"
     },
@@ -18726,6 +19049,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0i",
       "skos:prefLabel": "Bloomingdale Children's Picture Book"
     },
@@ -18736,6 +19060,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0n",
       "skos:prefLabel": "Bloomingdale Children's Non-Fiction"
     },
@@ -18746,8 +19071,20 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0l",
       "skos:prefLabel": "Bloomingdale Children's World Languages"
+    },
+    {
+      "@id": "nyplLocation:dha0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:dh"
+      },
+      "nypl:actualLocation": "Dongan Hills Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "dha0f",
+      "skos:prefLabel": "Dongan Hills Fiction"
     },
     {
       "@id": "nyplLocation:kb",
@@ -18783,7 +19120,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "map92",
       "skos:prefLabel": "SASB M2 - Map Division - Room 117"
@@ -18851,9 +19188,11 @@
         "@id": "nyplLocation:sl"
       },
       "nypl:actualLocation": "SIBL - Science Industry and Business",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:slr"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -18862,7 +19201,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "slr",
       "skos:prefLabel": "SIBL - Science Industry and Business"
@@ -18984,7 +19323,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating Children's Recorded Media",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -18998,6 +19337,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0i",
       "skos:prefLabel": "Epiphany Children's Picture Book"
     },
@@ -19082,14 +19422,14 @@
       "skos:prefLabel": "Roosevelt Island Children's World Languages"
     },
     {
-      "@id": "nyplLocation:dyj0f",
+      "@id": "nyplLocation:rij0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dy"
+        "@id": "nyplLocation:ri"
       },
-      "nypl:actualLocation": "Spuyten Duyvil Children's Fiction",
-      "skos:notation": "dyj0f",
-      "skos:prefLabel": "Spuyten Duyvil Children's Fiction"
+      "nypl:actualLocation": "Roosevelt Island Children's Non-Fiction",
+      "skos:notation": "rij0n",
+      "skos:prefLabel": "Roosevelt Island Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:mard2",
@@ -19118,6 +19458,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csa",
       "skos:prefLabel": "Columbus Adult"
     },
@@ -19168,6 +19509,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eayr",
       "skos:prefLabel": "Eastchester Young Adult Reference"
     },
@@ -19188,6 +19530,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ct",
       "skos:prefLabel": "Castle Hill"
     },
@@ -19261,6 +19604,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj",
       "skos:prefLabel": "Columbus Children"
     },
@@ -19328,7 +19672,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mapp2",
       "skos:prefLabel": "SASB - Map Division - Rm 117"
@@ -19350,6 +19694,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa0f",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Fiction"
     },
@@ -19370,6 +19715,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa0n",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Non-Fiction"
     },
@@ -19380,6 +19726,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa0l",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral World Languages"
     },
@@ -19390,6 +19737,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa0v",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Non-Print Media"
     },
@@ -19440,6 +19788,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa0v",
       "skos:prefLabel": "Francis Martin Non-Print Media"
     },
@@ -19464,14 +19813,14 @@
       "skos:prefLabel": "Andrew Heiskell Children's Disabilities Collection Fiction"
     },
     {
-      "@id": "nyplLocation:caj0v",
+      "@id": "nyplLocation:ftzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ca"
+        "@id": "nyplLocation:ft"
       },
-      "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media",
-      "skos:notation": "caj0v",
-      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media"
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ftzzz",
+      "skos:prefLabel": "53rd Street (error code)"
     },
     {
       "@id": "nyplLocation:fwy0v",
@@ -19480,6 +19829,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy0v",
       "skos:prefLabel": "Fort Washington YA Non-Print Media"
     },
@@ -19510,6 +19860,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy0l",
       "skos:prefLabel": "Fort Washington YA World Languages"
     },
@@ -19530,6 +19881,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy0n",
       "skos:prefLabel": "Fort Washington YA Non-Fiction"
     },
@@ -19540,6 +19892,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa0f",
       "skos:prefLabel": "Francis Martin Fiction"
     },
@@ -19580,6 +19933,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa0l",
       "skos:prefLabel": "Francis Martin World Languages"
     },
@@ -19590,6 +19944,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy0f",
       "skos:prefLabel": "Fort Washington YA Fiction"
     },
@@ -19600,6 +19955,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa0n",
       "skos:prefLabel": "Francis Martin Non-Fiction"
     },
@@ -19610,6 +19966,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0a",
       "skos:prefLabel": "Aguilar Children's Easy Book"
     },
@@ -19640,6 +19997,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0f",
       "skos:prefLabel": "Aguilar Children's Fiction"
     },
@@ -19650,6 +20008,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0h",
       "skos:prefLabel": "Aguilar Children's Holiday Book"
     },
@@ -19660,6 +20019,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0i",
       "skos:prefLabel": "Aguilar Children's Picture Book"
     },
@@ -19684,14 +20044,15 @@
       "skos:prefLabel": "Port Richmond Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:prj0n",
+      "@id": "nyplLocation:agj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:ag"
       },
-      "nypl:actualLocation": "Port Richmond Children's Non-Fiction",
-      "skos:notation": "prj0n",
-      "skos:prefLabel": "Port Richmond Children's Non-Fiction"
+      "nypl:actualLocation": "Aguilar Children's World Languages",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "agj0l",
+      "skos:prefLabel": "Aguilar Children's World Languages"
     },
     {
       "@id": "nyplLocation:rcmp2",
@@ -19700,9 +20061,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg - Maps Division",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:map"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1106"
       },
@@ -19714,14 +20072,35 @@
       "skos:prefLabel": "OFFSITE - Request in Advance for use at Schwarzman Bldg - Maps"
     },
     {
-      "@id": "nyplLocation:vnyr",
+      "@id": "nyplLocation:malw1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:vn"
+        "@id": "nyplLocation:ma"
       },
-      "nypl:actualLocation": "Van Nest Young Adult Reference",
-      "skos:notation": "vnyr",
-      "skos:prefLabel": "Pelham Parkway-Van Nest Young Adult Reference"
+      "nypl:actualLocation": "Schwarzman Building - Wertheim Study Rm 228W - Reference",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:malw"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "malw1",
+      "skos:prefLabel": "SASB - Wertheim Study Rm 228W - Reference"
+    },
+    {
+      "@id": "nyplLocation:caj0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ca"
+      },
+      "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "caj0v",
+      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:caa03",
@@ -19730,6 +20109,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa03",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Closed Shelf Reference"
     },
@@ -19740,6 +20120,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caa01",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Reference"
     },
@@ -19800,6 +20181,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj",
       "skos:prefLabel": "Francis Martin Children"
     },
@@ -19814,14 +20196,14 @@
       "skos:prefLabel": "West Farms Children's World Languages"
     },
     {
-      "@id": "nyplLocation:fxa03",
+      "@id": "nyplLocation:whj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fx"
+        "@id": "nyplLocation:wh"
       },
-      "nypl:actualLocation": "Francis Martin Closed Shelf Reference",
-      "skos:notation": "fxa03",
-      "skos:prefLabel": "Francis Martin Closed Shelf Reference"
+      "nypl:actualLocation": "Washington Heights Children's Easy Book",
+      "skos:notation": "whj0a",
+      "skos:prefLabel": "Washington Heights Children's Easy Book"
     },
     {
       "@id": "nyplLocation:rda",
@@ -19890,18 +20272,19 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy01",
       "skos:prefLabel": "Fort Washington YA Reference"
     },
     {
-      "@id": "nyplLocation:whj0i",
+      "@id": "nyplLocation:wkj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
+        "@id": "nyplLocation:wk"
       },
-      "nypl:actualLocation": "Washington Heights Children's Picture Book",
-      "skos:notation": "whj0i",
-      "skos:prefLabel": "Washington Heights Children's Picture Book"
+      "nypl:actualLocation": "Wakefield Children's Fairy Tale",
+      "skos:notation": "wkj0t",
+      "skos:prefLabel": "Wakefield Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:fxa",
@@ -19910,6 +20293,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa",
       "skos:prefLabel": "Francis Martin Adult"
     },
@@ -20000,6 +20384,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy",
       "skos:prefLabel": "Francis Martin Young Adult"
     },
@@ -20034,14 +20419,14 @@
       "skos:prefLabel": "Wakefield Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:whj0t",
+      "@id": "nyplLocation:wkj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
+        "@id": "nyplLocation:wk"
       },
-      "nypl:actualLocation": "Washington Heights Children's Fairy Tale",
-      "skos:notation": "whj0t",
-      "skos:prefLabel": "Washington Heights Children's Fairy Tale"
+      "nypl:actualLocation": "Wakefield Children's Picture Book",
+      "skos:notation": "wkj0i",
+      "skos:prefLabel": "Wakefield Children's Picture Book"
     },
     {
       "@id": "nyplLocation:wkj0f",
@@ -20120,6 +20505,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhy0n",
       "skos:prefLabel": "Dongan Hills YA Non-Fiction"
     },
@@ -20130,18 +20516,19 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj",
       "skos:prefLabel": "Dongan Hills Children"
     },
     {
-      "@id": "nyplLocation:wka",
+      "@id": "nyplLocation:rdy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wk"
+        "@id": "nyplLocation:rd"
       },
-      "nypl:actualLocation": "Wakefield Adult",
-      "skos:notation": "wka",
-      "skos:prefLabel": "Wakefield Adult"
+      "nypl:actualLocation": "Riverdale YA Fiction",
+      "skos:notation": "rdy0f",
+      "skos:prefLabel": "Riverdale YA Fiction"
     },
     {
       "@id": "nyplLocation:dha",
@@ -20150,6 +20537,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dha",
       "skos:prefLabel": "Dongan Hills Adult"
     },
@@ -20160,6 +20548,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhy0l",
       "skos:prefLabel": "Dongan Hills YA World Languages"
     },
@@ -20200,6 +20589,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhy",
       "skos:prefLabel": "Dongan Hills Young Adult"
     },
@@ -20240,6 +20630,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa01",
       "skos:prefLabel": "Clason's Point Reference"
     },
@@ -20250,28 +20641,20 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda03",
       "skos:prefLabel": "125th Street Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:tgjr",
+      "@id": "nyplLocation:bta0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
+        "@id": "nyplLocation:bt"
       },
-      "nypl:actualLocation": "Throg's Neck Children's Reference",
-      "skos:notation": "tgjr",
-      "skos:prefLabel": "Throg's Neck Children's Reference"
-    },
-    {
-      "@id": "nyplLocation:cpa03",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
-      },
-      "nypl:actualLocation": "Clason's Point Closed Shelf Reference",
-      "skos:notation": "cpa03",
-      "skos:prefLabel": "Clason's Point Closed Shelf Reference"
+      "nypl:actualLocation": "Battery Park Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "bta0f",
+      "skos:prefLabel": "Battery Park Fiction"
     },
     {
       "@id": "nyplLocation:sazzz",
@@ -20290,9 +20673,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg - Jewish Division",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:maf"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1103"
       },
@@ -20310,9 +20690,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg. - Jewish Divison",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:maf"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1103"
       },
@@ -20330,9 +20707,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "SASB Jewish--Offsite--Restricted",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:maf"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1103"
       },
@@ -20354,6 +20728,16 @@
       "skos:prefLabel": "Riverdale YA Reference"
     },
     {
+      "@id": "nyplLocation:prj0n",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:pr"
+      },
+      "nypl:actualLocation": "Port Richmond Children's Non-Fiction",
+      "skos:notation": "prj0n",
+      "skos:prefLabel": "Port Richmond Children's Non-Fiction"
+    },
+    {
       "@id": "nyplLocation:woyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -20370,6 +20754,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra0v",
       "skos:prefLabel": "George Bruce Non-Print Media"
     },
@@ -20380,6 +20765,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy01",
       "skos:prefLabel": "City Island YA Reference"
     },
@@ -20388,9 +20774,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
@@ -20413,14 +20796,18 @@
       "skos:prefLabel": "Countee Cullen Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:cayr",
+      "@id": "nyplLocation:ma0b",
       "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ca"
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:ma0b"
       },
-      "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Young Adult Reference",
-      "skos:notation": "cayr",
-      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference"
+      "nypl:deliveryLocationType": "Research",
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/NK"
+      },
+      "skos:notation": "ma0b",
+      "skos:prefLabel": "SASB - Barcoding Project"
     },
     {
       "@id": "nyplLocation:hta01",
@@ -20443,33 +20830,38 @@
       "skos:prefLabel": "Parkchester Young Adult"
     },
     {
-      "@id": "nyplLocation:pka",
+      "@id": "nyplLocation:sezzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:se"
       },
-      "nypl:actualLocation": "Parkchester Adult",
-      "skos:notation": "pka",
-      "skos:prefLabel": "Parkchester Adult"
+      "nypl:actualLocation": "Seward Park (error code)",
+      "skos:notation": "sezzz",
+      "skos:prefLabel": "Seward Park (error code)"
     },
     {
       "@id": "nyplLocation:ma0p",
       "@type": "nypl:Location",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:ma0p"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NT"
       },
       "skos:notation": "ma0p",
-      "skos:prefLabel": ""
+      "skos:prefLabel": "Photo Services and Permissions"
     },
     {
-      "@id": "nyplLocation:muj01",
+      "@id": "nyplLocation:pkj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:pk"
       },
-      "nypl:actualLocation": "Muhlenberg Children's Reference",
-      "skos:notation": "muj01",
-      "skos:prefLabel": "Muhlenberg Children's Reference"
+      "nypl:actualLocation": "Parkchester Children",
+      "skos:notation": "pkj",
+      "skos:prefLabel": "Parkchester Children"
     },
     {
       "@id": "nyplLocation:saj0t",
@@ -20532,14 +20924,15 @@
       "skos:prefLabel": "St. Agnes Children's Young Reader"
     },
     {
-      "@id": "nyplLocation:dhy0v",
+      "@id": "nyplLocation:brjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:br"
       },
-      "nypl:actualLocation": "Dongan Hills YA Non-Print Media",
-      "skos:notation": "dhy0v",
-      "skos:prefLabel": "Dongan Hills YA Non-Print Media"
+      "nypl:actualLocation": "George Bruce Children's Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "brjr",
+      "skos:prefLabel": "George Bruce Children's Reference"
     },
     {
       "@id": "nyplLocation:lmyr",
@@ -20628,6 +21021,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy0v",
       "skos:prefLabel": "City Island YA Non-Print Media"
     },
@@ -20636,9 +21030,6 @@
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
-      },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
       },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1001"
@@ -20667,6 +21058,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpjr",
       "skos:prefLabel": "Clason's Point Children's Reference"
     },
@@ -20687,6 +21079,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy0f",
       "skos:prefLabel": "City Island YA Fiction"
     },
@@ -20717,6 +21110,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy0n",
       "skos:prefLabel": "City Island YA Non-Fiction"
     },
@@ -20727,6 +21121,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy0l",
       "skos:prefLabel": "City Island YA World Languages"
     },
@@ -20756,9 +21151,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1116"
       },
@@ -20780,14 +21172,14 @@
       "skos:prefLabel": "St. Agnes Children's Reference"
     },
     {
-      "@id": "nyplLocation:eaj0i",
+      "@id": "nyplLocation:sbyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:sb"
       },
-      "nypl:actualLocation": "Eastchester Children's Picture Book",
-      "skos:notation": "eaj0i",
-      "skos:prefLabel": "Eastchester Children's Picture Book"
+      "nypl:actualLocation": "South Beach Young Adult Reference",
+      "skos:notation": "sbyr",
+      "skos:prefLabel": "South Beach Young Adult Reference"
     },
     {
       "@id": "nyplLocation:hky0f",
@@ -20800,22 +21192,13 @@
       "skos:prefLabel": "Huguenot Park YA Fiction"
     },
     {
-      "@id": "nyplLocation:sv",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sv"
-      },
-      "nypl:actualLocation": "Soundview",
-      "skos:notation": "sv",
-      "skos:prefLabel": "Soundview"
-    },
-    {
       "@id": "nyplLocation:hfyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfyr",
       "skos:prefLabel": "Hamilton Fish Park Young Adult Reference"
     },
@@ -20854,7 +21237,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mapp3",
       "skos:prefLabel": "SASB - Map Division - Desk - Rm 117"
@@ -20884,20 +21267,20 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "slr12",
       "skos:prefLabel": "SIBL - B. Altman Desk"
     },
     {
-      "@id": "nyplLocation:woj0h",
+      "@id": "nyplLocation:pka",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wo"
+        "@id": "nyplLocation:pk"
       },
-      "nypl:actualLocation": "Woodstock Children's Holiday Book",
-      "skos:notation": "woj0h",
-      "skos:prefLabel": "Woodstock Children's Holiday Book"
+      "nypl:actualLocation": "Parkchester Adult",
+      "skos:notation": "pka",
+      "skos:prefLabel": "Parkchester Adult"
     },
     {
       "@id": "nyplLocation:woj0i",
@@ -20936,6 +21319,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa03",
       "skos:prefLabel": "Baychester Closed Shelf Reference"
     },
@@ -20976,6 +21360,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bra03",
       "skos:prefLabel": "George Bruce Closed Shelf Reference"
     },
@@ -21016,6 +21401,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy01",
       "skos:prefLabel": "Aguilar YA Reference"
     },
@@ -21116,6 +21502,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy0n",
       "skos:prefLabel": "Aguilar YA Non-Fiction"
     },
@@ -21126,6 +21513,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy0l",
       "skos:prefLabel": "Aguilar YA World Languages"
     },
@@ -21166,6 +21554,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0y",
       "skos:prefLabel": "Eastchester Children's Young Reader"
     },
@@ -21176,6 +21565,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fe",
       "skos:prefLabel": "58th Street"
     },
@@ -21186,6 +21576,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy0f",
       "skos:prefLabel": "Aguilar YA Fiction"
     },
@@ -21235,6 +21626,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa0n",
       "skos:prefLabel": "Baychester Non-Fiction"
     },
@@ -21255,6 +21647,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa0l",
       "skos:prefLabel": "Baychester World Languages"
     },
@@ -21285,6 +21678,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa0f",
       "skos:prefLabel": "Baychester Fiction"
     },
@@ -21295,6 +21689,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agy0v",
       "skos:prefLabel": "Aguilar YA Non-Print Media"
     },
@@ -21305,6 +21700,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fw",
       "skos:prefLabel": "Fort Washington"
     },
@@ -21325,6 +21721,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj01",
       "skos:prefLabel": "Aguilar Children's Reference"
     },
@@ -21405,16 +21802,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - TOFT",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1120"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myf22",
       "skos:prefLabel": "Performing Arts Research Collections - TOFT"
@@ -21496,6 +21893,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj",
       "skos:prefLabel": "Morningside Heights Children"
     },
@@ -21506,18 +21904,19 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blar",
       "skos:prefLabel": "Bloomingdale Adult Reference"
     },
     {
-      "@id": "nyplLocation:cia0l",
+      "@id": "nyplLocation:inj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ci"
+        "@id": "nyplLocation:in"
       },
-      "nypl:actualLocation": "City Island World Languages",
-      "skos:notation": "cia0l",
-      "skos:prefLabel": "City Island World Languages"
+      "nypl:actualLocation": "Inwood Children's Holiday Book",
+      "skos:notation": "inj0h",
+      "skos:prefLabel": "Inwood Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:bea03",
@@ -21526,6 +21925,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea03",
       "skos:prefLabel": "Belmont Closed Shelf Reference"
     },
@@ -21536,6 +21936,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea01",
       "skos:prefLabel": "Belmont Reference"
     },
@@ -21559,6 +21960,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baj",
       "skos:prefLabel": "Baychester Children"
     },
@@ -21579,6 +21981,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa",
       "skos:prefLabel": "Baychester Adult"
     },
@@ -21599,6 +22002,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bay",
       "skos:prefLabel": "Baychester Young Adult"
     },
@@ -21629,6 +22033,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cla",
       "skos:prefLabel": "Morningside Heights Adult"
     },
@@ -21639,6 +22044,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea0f",
       "skos:prefLabel": "Belmont Fiction"
     },
@@ -21663,24 +22069,30 @@
       "skos:prefLabel": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg -"
     },
     {
-      "@id": "nyplLocation:mry0v",
+      "@id": "nyplLocation:sla0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mr"
+        "@id": "nyplLocation:sl"
       },
-      "nypl:actualLocation": "Morrisania YA Non-Print Media",
-      "skos:notation": "mry0v",
-      "skos:prefLabel": "Morrisania YA Non-Print Media"
+      "nypl:actualLocation": "SIBL - Non-Fiction",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1125"
+      },
+      "skos:notation": "sla0n",
+      "skos:prefLabel": "SIBL - Non-Fiction"
     },
     {
-      "@id": "nyplLocation:rty0v",
+      "@id": "nyplLocation:mma2f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
+        "@id": "nyplLocation:mm"
       },
-      "nypl:actualLocation": "Richmondtown YA Non-Print Media",
-      "skos:notation": "rty0v",
-      "skos:prefLabel": "Richmondtown YA Non-Print Media"
+      "nypl:actualLocation": "Mid-Manhattan Fiction Second Floor",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "skos:notation": "mma2f",
+      "skos:prefLabel": "Mid-Manhattan Fiction Second Floor"
     },
     {
       "@id": "nyplLocation:bea0n",
@@ -21689,6 +22101,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea0n",
       "skos:prefLabel": "Belmont Non-Fiction"
     },
@@ -21699,6 +22112,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea0l",
       "skos:prefLabel": "Belmont World Languages"
     },
@@ -21716,14 +22130,14 @@
       "skos:prefLabel": "SIBL - Fiction"
     },
     {
-      "@id": "nyplLocation:hda0v",
+      "@id": "nyplLocation:tgar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hd"
+        "@id": "nyplLocation:tg"
       },
-      "nypl:actualLocation": "125th Street Non-Print Media",
-      "skos:notation": "hda0v",
-      "skos:prefLabel": "125th Street Non-Print Media"
+      "nypl:actualLocation": "Throg's Neck Adult Reference",
+      "skos:notation": "tgar",
+      "skos:prefLabel": "Throg's Neck Adult Reference"
     },
     {
       "@id": "nyplLocation:bea0v",
@@ -21732,6 +22146,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea0v",
       "skos:prefLabel": "Belmont Non-Print Media"
     },
@@ -21805,6 +22220,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fezzz",
       "skos:prefLabel": "58th Street (error code)"
     },
@@ -21815,18 +22231,9 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay0v",
       "skos:prefLabel": "Eastchester YA Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:rdj0t",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
-      },
-      "nypl:actualLocation": "Riverdale Children's Fairy Tale",
-      "skos:notation": "rdj0t",
-      "skos:prefLabel": "Riverdale Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:be",
@@ -21835,6 +22242,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont",
+      "nypl:collectionType": "Branch",
       "skos:notation": "be",
       "skos:prefLabel": "Belmont"
     },
@@ -21845,6 +22253,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay0f",
       "skos:prefLabel": "Eastchester YA Fiction"
     },
@@ -21855,6 +22264,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay0l",
       "skos:prefLabel": "Eastchester YA World Languages"
     },
@@ -21865,6 +22275,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay0n",
       "skos:prefLabel": "Eastchester YA Non-Fiction"
     },
@@ -21875,6 +22286,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhy01",
       "skos:prefLabel": "Dongan Hills YA Reference"
     },
@@ -21895,6 +22307,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blj0h",
       "skos:prefLabel": "Bloomingdale Children's Holiday Book"
     },
@@ -21905,6 +22318,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cljr",
       "skos:prefLabel": "Morningside Heights Children's Reference"
     },
@@ -21925,7 +22339,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts - Orchestra Collection",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -21953,14 +22367,14 @@
       "skos:prefLabel": "Stapleton YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:hkj0i",
+      "@id": "nyplLocation:muj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hk"
+        "@id": "nyplLocation:mu"
       },
-      "nypl:actualLocation": "Huguenot Park Children's Picture Book",
-      "skos:notation": "hkj0i",
-      "skos:prefLabel": "Huguenot Park Children's Picture Book"
+      "nypl:actualLocation": "Muhlenberg Children's Non-Print Media",
+      "skos:notation": "muj0v",
+      "skos:prefLabel": "Muhlenberg Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:macc2",
@@ -21999,6 +22413,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwa",
       "skos:prefLabel": "Fort Washington Adult"
     },
@@ -22009,6 +22424,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eay01",
       "skos:prefLabel": "Eastchester YA Reference"
     },
@@ -22039,6 +22455,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwy",
       "skos:prefLabel": "Fort Washington Young Adult"
     },
@@ -22091,27 +22508,6 @@
       "nypl:actualLocation": "Countee Cullen Children's Non-Fiction",
       "skos:notation": "htj0n",
       "skos:prefLabel": "Countee Cullen Children's Non-Fiction"
-    },
-    {
-      "@id": "nyplLocation:mym42",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
-      },
-      "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:locationType": "Research",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1002"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "mym42",
-      "skos:prefLabel": "OFFSITE Rose - Request in advance for use at Performing Arts"
     },
     {
       "@id": "nyplLocation:htj0a",
@@ -22170,6 +22566,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbj0n",
       "skos:prefLabel": "High Bridge Children's Non-Fiction"
     },
@@ -22190,6 +22587,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdjr",
       "skos:prefLabel": "125th Street Children's Reference"
     },
@@ -22202,16 +22600,6 @@
       "nypl:actualLocation": "Countee Cullen Children's Non-Print Media",
       "skos:notation": "htj0v",
       "skos:prefLabel": "Countee Cullen Children's Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:clzzz",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cl"
-      },
-      "nypl:actualLocation": "Morningside Heights (error code)",
-      "skos:notation": "clzzz",
-      "skos:prefLabel": "Morningside Heights (error code)"
     },
     {
       "@id": "nyplLocation:iny01",
@@ -22250,6 +22638,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0l",
       "skos:prefLabel": "Epiphany Children's World Languages"
     },
@@ -22270,9 +22659,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg - Local History & Geneology",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mag"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1105"
       },
@@ -22320,9 +22706,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "SASB LHG--Offsite--Restricted",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mag"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -22340,9 +22723,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at SASB Local History & Geneology",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mag"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1105"
       },
@@ -22410,6 +22790,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj01",
       "skos:prefLabel": "Epiphany Children's Reference"
     },
@@ -22430,9 +22811,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Performing Arts",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -22540,6 +22918,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyzzz",
       "skos:prefLabel": "Spuyten Duyvil (error code)"
     },
@@ -22614,24 +22993,24 @@
       "skos:prefLabel": "Inwood YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:wta01",
+      "@id": "nyplLocation:thjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:th"
       },
-      "nypl:actualLocation": "Westchester Square Reference",
-      "skos:notation": "wta01",
-      "skos:prefLabel": "Westchester Square Reference"
+      "nypl:actualLocation": "Todt Hill-Westerleigh Children's Reference",
+      "skos:notation": "thjr",
+      "skos:prefLabel": "Todt Hill-Westerleigh Children's Reference"
     },
     {
-      "@id": "nyplLocation:fey",
+      "@id": "nyplLocation:sgj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:sg"
       },
-      "nypl:actualLocation": "58th Street Young Adult",
-      "skos:notation": "fey",
-      "skos:prefLabel": "58th Street Young Adult"
+      "nypl:actualLocation": "St. George Children's Non-Fiction",
+      "skos:notation": "sgj0n",
+      "skos:prefLabel": "St. George Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:epj0h",
@@ -22640,6 +23019,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0h",
       "skos:prefLabel": "Epiphany Children's Holiday Book"
     },
@@ -22684,24 +23064,24 @@
       "skos:prefLabel": "St. George Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:epj0a",
+      "@id": "nyplLocation:sgj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ep"
+        "@id": "nyplLocation:sg"
       },
-      "nypl:actualLocation": "Epiphany Children's Easy Book",
-      "skos:notation": "epj0a",
-      "skos:prefLabel": "Epiphany Children's Easy Book"
+      "nypl:actualLocation": "St. George Children's Fiction",
+      "skos:notation": "sgj0f",
+      "skos:prefLabel": "St. George Children's Fiction"
     },
     {
-      "@id": "nyplLocation:pra0f",
+      "@id": "nyplLocation:wta03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:wt"
       },
-      "nypl:actualLocation": "Port Richmond Fiction",
-      "skos:notation": "pra0f",
-      "skos:prefLabel": "Port Richmond Fiction"
+      "nypl:actualLocation": "Westchester Square Closed Shelf Reference",
+      "skos:notation": "wta03",
+      "skos:prefLabel": "Westchester Square Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:wlj01",
@@ -22730,6 +23110,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0y",
       "skos:prefLabel": "Epiphany Children's Young Reader"
     },
@@ -22740,6 +23121,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fej",
       "skos:prefLabel": "58th Street Children"
     },
@@ -22764,24 +23146,25 @@
       "skos:prefLabel": "St. George Children's Young Reader"
     },
     {
-      "@id": "nyplLocation:sgj0v",
+      "@id": "nyplLocation:fea",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:fe"
       },
-      "nypl:actualLocation": "St. George Children's Non-Print Media",
-      "skos:notation": "sgj0v",
-      "skos:prefLabel": "St. George Children's Non-Print Media"
+      "nypl:actualLocation": "58th Street Adult",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fea",
+      "skos:prefLabel": "58th Street Adult"
     },
     {
-      "@id": "nyplLocation:rdj0l",
+      "@id": "nyplLocation:prj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
+        "@id": "nyplLocation:pr"
       },
-      "nypl:actualLocation": "Riverdale Children's World Languages",
-      "skos:notation": "rdj0l",
-      "skos:prefLabel": "Riverdale Children's World Languages"
+      "nypl:actualLocation": "Port Richmond Children's Non-Print Media",
+      "skos:notation": "prj0v",
+      "skos:prefLabel": "Port Richmond Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:sgj0t",
@@ -22800,6 +23183,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0t",
       "skos:prefLabel": "Epiphany Children's Fairy Tale"
     },
@@ -22810,6 +23194,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0v",
       "skos:prefLabel": "Epiphany Children's Non-Print Media"
     },
@@ -22840,6 +23225,7 @@
         "@id": "nyplLocation:gd"
       },
       "nypl:actualLocation": "Grand Concourse",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gd",
       "skos:prefLabel": "Grand Concourse"
     },
@@ -22850,6 +23236,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay0l",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA World Languages"
     },
@@ -22860,6 +23247,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gc",
       "skos:prefLabel": "Grand Central"
     },
@@ -22870,17 +23258,27 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy0f",
       "skos:prefLabel": "Spuyten Duyvil YA Fiction"
     },
     {
       "@id": "nyplLocation:go",
       "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:slr"
+      },
+      "nypl:actualLocation": "SIBL - Science Industry and Business",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:go"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/GO"
       },
       "skos:notation": "go",
-      "skos:prefLabel": ""
+      "skos:prefLabel": "SIBL - Google Books Project"
     },
     {
       "@id": "nyplLocation:ina",
@@ -22899,6 +23297,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy0l",
       "skos:prefLabel": "Spuyten Duyvil YA World Languages"
     },
@@ -22929,6 +23328,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy0n",
       "skos:prefLabel": "Spuyten Duyvil YA Non-Fiction"
     },
@@ -22949,6 +23349,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj01",
       "skos:prefLabel": "Fort Washington Children's Reference"
     },
@@ -22959,6 +23360,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy0v",
       "skos:prefLabel": "Spuyten Duyvil YA Non-Print Media"
     },
@@ -22969,6 +23371,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0y",
       "skos:prefLabel": "Aguilar Children's Young Reader"
     },
@@ -23022,7 +23425,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Song Index Reference Score",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -23056,6 +23459,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy0v",
       "skos:prefLabel": "Francis Martin YA Non-Print Media"
     },
@@ -23085,6 +23489,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy0l",
       "skos:prefLabel": "Francis Martin YA World Languages"
     },
@@ -23095,6 +23500,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy0n",
       "skos:prefLabel": "Francis Martin YA Non-Fiction"
     },
@@ -23125,6 +23531,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy0f",
       "skos:prefLabel": "Francis Martin YA Fiction"
     },
@@ -23135,6 +23542,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxa01",
       "skos:prefLabel": "Francis Martin Reference"
     },
@@ -23145,6 +23553,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0a",
       "skos:prefLabel": "Fort Washington Children's Easy Book"
     },
@@ -23165,6 +23574,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0f",
       "skos:prefLabel": "Fort Washington Children's Fiction"
     },
@@ -23174,6 +23584,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0y",
       "skos:prefLabel": "53rd Street Children's Young Reader"
     },
@@ -23183,17 +23594,20 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0v",
       "skos:prefLabel": "53rd Street Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:ftj0t",
+      "@id": "nyplLocation:fwj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ft"
+        "@id": "nyplLocation:fw"
       },
-      "skos:notation": "ftj0t",
-      "skos:prefLabel": "53rd Street Children's Fairy Tale"
+      "nypl:actualLocation": "Fort Washington Children's Picture Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fwj0i",
+      "skos:prefLabel": "Fort Washington Children's Picture Book"
     },
     {
       "@id": "nyplLocation:fwj0h",
@@ -23202,6 +23616,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0h",
       "skos:prefLabel": "Fort Washington Children's Holiday Book"
     },
@@ -23212,6 +23627,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0n",
       "skos:prefLabel": "Fort Washington Children's Non-Fiction"
     },
@@ -23222,6 +23638,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0l",
       "skos:prefLabel": "Fort Washington Children's World Languages"
     },
@@ -23231,6 +23648,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0n",
       "skos:prefLabel": "53rd Street Children's Non-Fiction"
     },
@@ -23241,6 +23659,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy01",
       "skos:prefLabel": "Spuyten Duyvil YA Reference"
     },
@@ -23250,18 +23669,19 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0l",
       "skos:prefLabel": "53rd Street Children's World Languages"
     },
     {
-      "@id": "nyplLocation:cpj0l",
+      "@id": "nyplLocation:wfj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:wf"
       },
-      "nypl:actualLocation": "Clason's Point Children's World Languages",
-      "skos:notation": "cpj0l",
-      "skos:prefLabel": "Clason's Point Children's World Languages"
+      "nypl:actualLocation": "West Farms Children's Non-Fiction",
+      "skos:notation": "wfj0n",
+      "skos:prefLabel": "West Farms Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:fwj0v",
@@ -23270,6 +23690,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0v",
       "skos:prefLabel": "Fort Washington Children's Non-Print Media"
     },
@@ -23279,6 +23700,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0h",
       "skos:prefLabel": "53rd Street Children's Holiday Book"
     },
@@ -23288,6 +23710,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0i",
       "skos:prefLabel": "53rd Street Children's Picture Book"
     },
@@ -23297,6 +23720,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0f",
       "skos:prefLabel": "53rd Street Children's Fiction"
     },
@@ -23317,6 +23741,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwj0y",
       "skos:prefLabel": "Fort Washington Children's Young Reader"
     },
@@ -23337,6 +23762,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cay01",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA Reference"
     },
@@ -23346,6 +23772,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftj0a",
       "skos:prefLabel": "53rd Street Children's Easy Book"
     },
@@ -23366,29 +23793,19 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxy01",
       "skos:prefLabel": "Francis Martin YA Reference"
     },
     {
-      "@id": "nyplLocation:mym38",
+      "@id": "nyplLocation:hsj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
+        "@id": "nyplLocation:hs"
       },
-      "nypl:actualLocation": "Performing Arts Research Collections - Music",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:locationType": "Research",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1123"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "mym38",
-      "skos:prefLabel": "Performing Arts Research Collections - Music"
+      "nypl:actualLocation": "Hunt's Point Children's Young Reader",
+      "skos:notation": "hsj0y",
+      "skos:prefLabel": "Hunt's Point Children's Young Reader"
     },
     {
       "@id": "nyplLocation:wkj0v",
@@ -23427,18 +23844,19 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0f",
       "skos:prefLabel": "Clason's Point Children's Fiction"
     },
     {
-      "@id": "nyplLocation:wkj0t",
+      "@id": "nyplLocation:whj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wk"
+        "@id": "nyplLocation:wh"
       },
-      "nypl:actualLocation": "Wakefield Children's Fairy Tale",
-      "skos:notation": "wkj0t",
-      "skos:prefLabel": "Wakefield Children's Fairy Tale"
+      "nypl:actualLocation": "Washington Heights Children's Picture Book",
+      "skos:notation": "whj0i",
+      "skos:prefLabel": "Washington Heights Children's Picture Book"
     },
     {
       "@id": "nyplLocation:tsj0y",
@@ -23471,14 +23889,15 @@
       "skos:prefLabel": "Washington Heights Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:mua0f",
+      "@id": "nyplLocation:alzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:al"
       },
-      "nypl:actualLocation": "Muhlenberg Fiction",
-      "skos:notation": "mua0f",
-      "skos:prefLabel": "Muhlenberg Fiction"
+      "nypl:actualLocation": "Allerton (error code)",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "alzzz",
+      "skos:prefLabel": "Allerton (error code)"
     },
     {
       "@id": "nyplLocation:rdj0v",
@@ -23497,18 +23916,19 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csjr",
       "skos:prefLabel": "Columbus Children's Reference"
     },
     {
-      "@id": "nyplLocation:tsj0t",
+      "@id": "nyplLocation:mua0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
+        "@id": "nyplLocation:mu"
       },
-      "nypl:actualLocation": "Tompkins Square Children's Fairy Tale",
-      "skos:notation": "tsj0t",
-      "skos:prefLabel": "Tompkins Square Children's Fairy Tale"
+      "nypl:actualLocation": "Muhlenberg World Languages",
+      "skos:notation": "mua0l",
+      "skos:prefLabel": "Muhlenberg World Languages"
     },
     {
       "@id": "nyplLocation:tsj0v",
@@ -23547,17 +23967,9 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clj0h",
       "skos:prefLabel": "Morningside Heights Children's Holiday Book"
-    },
-    {
-      "@id": "nyplLocation:ftzzz",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ft"
-      },
-      "skos:notation": "ftzzz",
-      "skos:prefLabel": "53rd Street (error code)"
     },
     {
       "@id": "nyplLocation:tsj0l",
@@ -23665,6 +24077,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0l",
       "skos:prefLabel": "Great Kills Children's World Languages"
     },
@@ -23695,6 +24108,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0h",
       "skos:prefLabel": "Great Kills Children's Holiday Book"
     },
@@ -23745,7 +24159,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Reference",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -23779,7 +24193,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Closed Shelf Reference",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -23807,14 +24221,14 @@
       "skos:prefLabel": "Soundview Children's Young Reader"
     },
     {
-      "@id": "nyplLocation:rta",
+      "@id": "nyplLocation:muj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
+        "@id": "nyplLocation:mu"
       },
-      "nypl:actualLocation": "Richmondtown Adult",
-      "skos:notation": "rta",
-      "skos:prefLabel": "Richmondtown Adult"
+      "nypl:actualLocation": "Muhlenberg Children's Reference",
+      "skos:notation": "muj01",
+      "skos:prefLabel": "Muhlenberg Children's Reference"
     },
     {
       "@id": "nyplLocation:ssa0l",
@@ -23833,6 +24247,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0y",
       "skos:prefLabel": "Great Kills Children's Young Reader"
     },
@@ -23843,6 +24258,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0v",
       "skos:prefLabel": "Great Kills Children's Non-Print Media"
     },
@@ -23863,6 +24279,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj0t",
       "skos:prefLabel": "Great Kills Children's Fairy Tale"
     },
@@ -23897,24 +24314,15 @@
       "skos:prefLabel": "Mott Haven Reference"
     },
     {
-      "@id": "nyplLocation:hty0v",
+      "@id": "nyplLocation:cpj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ht"
+        "@id": "nyplLocation:cp"
       },
-      "nypl:actualLocation": "Countee Cullen YA Non-Print Media",
-      "skos:notation": "hty0v",
-      "skos:prefLabel": "Countee Cullen YA Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:hgy01",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:hg"
-      },
-      "nypl:actualLocation": "Hamilton Grange YA Reference",
-      "skos:notation": "hgy01",
-      "skos:prefLabel": "Hamilton Grange YA Reference"
+      "nypl:actualLocation": "Clason's Point Children's Young Reader",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cpj0y",
+      "skos:prefLabel": "Clason's Point Children's Young Reader"
     },
     {
       "@id": "nyplLocation:tsj01",
@@ -23927,14 +24335,14 @@
       "skos:prefLabel": "Tompkins Square Children's Reference"
     },
     {
-      "@id": "nyplLocation:wkj0i",
+      "@id": "nyplLocation:whj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wk"
+        "@id": "nyplLocation:wh"
       },
-      "nypl:actualLocation": "Wakefield Children's Picture Book",
-      "skos:notation": "wkj0i",
-      "skos:prefLabel": "Wakefield Children's Picture Book"
+      "nypl:actualLocation": "Washington Heights Children's Fairy Tale",
+      "skos:notation": "whj0t",
+      "skos:prefLabel": "Washington Heights Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:ctyr",
@@ -23943,6 +24351,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctyr",
       "skos:prefLabel": "Castle Hill Young Adult Reference"
     },
@@ -23957,14 +24366,14 @@
       "skos:prefLabel": "Parkchester YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:csj0h",
+      "@id": "nyplLocation:wlyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cs"
+        "@id": "nyplLocation:wl"
       },
-      "nypl:actualLocation": "Columbus Children's Holiday Book",
-      "skos:notation": "csj0h",
-      "skos:prefLabel": "Columbus Children's Holiday Book"
+      "nypl:actualLocation": "Woodlawn Heights Young Adult Reference",
+      "skos:notation": "wlyr",
+      "skos:prefLabel": "Woodlawn Heights Young Adult Reference"
     },
     {
       "@id": "nyplLocation:pky0l",
@@ -24033,6 +24442,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpj0t",
       "skos:prefLabel": "Clason's Point Children's Fairy Tale"
     },
@@ -24043,10 +24453,10 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Dance - Reference",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1121"
       },
@@ -24084,7 +24494,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating Recorded Media",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -24098,7 +24508,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating Score",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -24112,7 +24522,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Circulating Non-Fiction",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -24176,6 +24586,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkj01",
       "skos:prefLabel": "Great Kills Children's Reference"
     },
@@ -24336,18 +24747,19 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hby",
       "skos:prefLabel": "High Bridge Young Adult"
     },
     {
-      "@id": "nyplLocation:sea0w",
+      "@id": "nyplLocation:sbj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:sb"
       },
-      "nypl:actualLocation": "Seward Park Center for Reading & Writing",
-      "skos:notation": "sea0w",
-      "skos:prefLabel": "Seward Park Center for Reading & Writing"
+      "nypl:actualLocation": "South Beach Children's Picture Book",
+      "skos:notation": "sbj0i",
+      "skos:prefLabel": "South Beach Children's Picture Book"
     },
     {
       "@id": "nyplLocation:sea0v",
@@ -24365,6 +24777,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty",
       "skos:prefLabel": "53rd Street Young Adult"
     },
@@ -24375,6 +24788,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta",
       "skos:prefLabel": "Battery Park Adult"
     },
@@ -24405,6 +24819,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj",
       "skos:prefLabel": "Battery Park Children"
     },
@@ -24494,6 +24909,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "fty0v",
       "skos:prefLabel": "53rd Street YA Non-Print Media"
     },
@@ -24524,6 +24940,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty",
       "skos:prefLabel": "Battery Park Young Adult"
     },
@@ -24554,7 +24971,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Reserve Film and Video Children's Fiction",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "skos:notation": "myjrv",
       "skos:prefLabel": "Reserve Film and Video Children's Fiction"
     },
@@ -24634,6 +25051,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdyr",
       "skos:prefLabel": "125th Street Young Adult Reference"
     },
@@ -24678,6 +25096,16 @@
       "skos:prefLabel": "Van Cortlandt Children's Non-Fiction"
     },
     {
+      "@id": "nyplLocation:ndj0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:nd"
+      },
+      "nypl:actualLocation": "New Dorp Children's Fiction",
+      "skos:notation": "ndj0f",
+      "skos:prefLabel": "New Dorp Children's Fiction"
+    },
+    {
       "@id": "nyplLocation:vcj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -24688,14 +25116,14 @@
       "skos:prefLabel": "Van Cortlandt Children's World Languages"
     },
     {
-      "@id": "nyplLocation:jmjr",
+      "@id": "nyplLocation:hpy",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:jm"
+        "@id": "nyplLocation:hp"
       },
-      "nypl:actualLocation": "Jefferson Market Children's Reference",
-      "skos:notation": "jmjr",
-      "skos:prefLabel": "Jefferson Market Children's Reference"
+      "nypl:actualLocation": "Hudson Park Young Adult",
+      "skos:notation": "hpy",
+      "skos:prefLabel": "Hudson Park Young Adult"
     },
     {
       "@id": "nyplLocation:vcj0i",
@@ -24744,6 +25172,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0i",
       "skos:prefLabel": "Spuyten Duyvil Children's Picture Book"
     },
@@ -24754,6 +25183,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0h",
       "skos:prefLabel": "Spuyten Duyvil Children's Holiday Book"
     },
@@ -24774,6 +25204,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0n",
       "skos:prefLabel": "Spuyten Duyvil Children's Non-Fiction"
     },
@@ -24784,6 +25215,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0l",
       "skos:prefLabel": "Spuyten Duyvil Children's World Languages"
     },
@@ -24794,6 +25226,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0a",
       "skos:prefLabel": "Spuyten Duyvil Children's Easy Book"
     },
@@ -24824,6 +25257,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hby01",
       "skos:prefLabel": "High Bridge YA Reference"
     },
@@ -24834,6 +25268,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0y",
       "skos:prefLabel": "Spuyten Duyvil Children's Young Reader"
     },
@@ -24884,6 +25319,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0v",
       "skos:prefLabel": "Spuyten Duyvil Children's Non-Print Media"
     },
@@ -24894,8 +25330,20 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj0t",
       "skos:prefLabel": "Spuyten Duyvil Children's Fairy Tale"
+    },
+    {
+      "@id": "nyplLocation:hbj0y",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:hb"
+      },
+      "nypl:actualLocation": "High Bridge Children's Young Reader",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hbj0y",
+      "skos:prefLabel": "High Bridge Children's Young Reader"
     },
     {
       "@id": "nyplLocation:inj01",
@@ -24914,18 +25362,19 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia03",
       "skos:prefLabel": "City Island Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:yva",
+      "@id": "nyplLocation:wta0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:yv"
+        "@id": "nyplLocation:wt"
       },
-      "nypl:actualLocation": "Yorkville Adult",
-      "skos:notation": "yva",
-      "skos:prefLabel": "Yorkville Adult"
+      "nypl:actualLocation": "Westchester Square Fiction",
+      "skos:notation": "wta0f",
+      "skos:prefLabel": "Westchester Square Fiction"
     },
     {
       "@id": "nyplLocation:cia01",
@@ -24934,6 +25383,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia01",
       "skos:prefLabel": "City Island Reference"
     },
@@ -24944,18 +25394,9 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epzzz",
       "skos:prefLabel": "Epiphany (error code)"
-    },
-    {
-      "@id": "nyplLocation:tsy0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
-      },
-      "nypl:actualLocation": "Tompkins Square YA World Languages",
-      "skos:notation": "tsy0l",
-      "skos:prefLabel": "Tompkins Square YA World Languages"
     },
     {
       "@id": "nyplLocation:dhzzz",
@@ -24964,6 +25405,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhzzz",
       "skos:prefLabel": "Dongan Hills (error code)"
     },
@@ -24974,6 +25416,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcjr",
       "skos:prefLabel": "Grand Central Children's Reference"
     },
@@ -24994,6 +25437,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hby0f",
       "skos:prefLabel": "High Bridge YA Fiction"
     },
@@ -25027,18 +25471,20 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hby0l",
       "skos:prefLabel": "High Bridge YA World Languages"
     },
     {
-      "@id": "nyplLocation:mhj0v",
+      "@id": "nyplLocation:hby0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mh"
+        "@id": "nyplLocation:hb"
       },
-      "nypl:actualLocation": "Mott Haven Children's Non-Print Media",
-      "skos:notation": "mhj0v",
-      "skos:prefLabel": "Mott Haven Children's Non-Print Media"
+      "nypl:actualLocation": "High Bridge YA Non-Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hby0n",
+      "skos:prefLabel": "High Bridge YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:rtj0i",
@@ -25057,6 +25503,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hby0v",
       "skos:prefLabel": "High Bridge YA Non-Print Media"
     },
@@ -25067,6 +25514,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Reading Room",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj01",
       "skos:prefLabel": "Spuyten Duyvil Children's Reading Room"
     },
@@ -25077,6 +25525,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csj0a",
       "skos:prefLabel": "Columbus Children's Easy Book"
     },
@@ -25117,18 +25566,19 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia0v",
       "skos:prefLabel": "City Island Non-Print Media"
     },
     {
-      "@id": "nyplLocation:rdy0f",
+      "@id": "nyplLocation:wka",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
+        "@id": "nyplLocation:wk"
       },
-      "nypl:actualLocation": "Riverdale YA Fiction",
-      "skos:notation": "rdy0f",
-      "skos:prefLabel": "Riverdale YA Fiction"
+      "nypl:actualLocation": "Wakefield Adult",
+      "skos:notation": "wka",
+      "skos:prefLabel": "Wakefield Adult"
     },
     {
       "@id": "nyplLocation:inj0v",
@@ -25157,6 +25607,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia0n",
       "skos:prefLabel": "City Island Non-Fiction"
     },
@@ -25171,14 +25622,15 @@
       "skos:prefLabel": "Inwood Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:inj0h",
+      "@id": "nyplLocation:cia0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:in"
+        "@id": "nyplLocation:ci"
       },
-      "nypl:actualLocation": "Inwood Children's Holiday Book",
-      "skos:notation": "inj0h",
-      "skos:prefLabel": "Inwood Children's Holiday Book"
+      "nypl:actualLocation": "City Island World Languages",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cia0l",
+      "skos:prefLabel": "City Island World Languages"
     },
     {
       "@id": "nyplLocation:inj0n",
@@ -25207,6 +25659,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia0f",
       "skos:prefLabel": "City Island Fiction"
     },
@@ -25247,38 +25700,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -25324,7 +25745,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mabb2",
       "skos:prefLabel": "SASB - Art & Architecture Rm 300"
@@ -25381,6 +25802,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aly",
       "skos:prefLabel": "Allerton Young Adult"
     },
@@ -25390,47 +25812,6 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:rc"
       },
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:map"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -25478,6 +25859,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "alj",
       "skos:prefLabel": "Allerton Children"
     },
@@ -25488,6 +25870,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caar",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Adult Reference"
     },
@@ -25508,6 +25891,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ala",
       "skos:prefLabel": "Allerton Adult"
     },
@@ -25558,6 +25942,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epy0f",
       "skos:prefLabel": "Epiphany YA Fiction"
     },
@@ -25568,6 +25953,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "clar",
       "skos:prefLabel": "Morningside Heights Adult Reference"
     },
@@ -25598,6 +25984,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "blzzz",
       "skos:prefLabel": "Bloomingdale (error code)"
     },
@@ -25621,6 +26008,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewy0f",
       "skos:prefLabel": "Edenwald YA Fiction"
     },
@@ -25758,6 +26146,26 @@
       "skos:prefLabel": "Seward Park Children's Young Reader"
     },
     {
+      "@id": "nyplLocation:mar82",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:Ma"
+      },
+      "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:mar"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1108"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "mar82",
+      "skos:prefLabel": "SASB - Rare Book Collection Rm 328"
+    },
+    {
       "@id": "nyplLocation:sej0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -25784,6 +26192,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa0v",
       "skos:prefLabel": "Hamilton Fish Park Non-Print Media"
     },
@@ -25844,6 +26253,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa0n",
       "skos:prefLabel": "Hamilton Fish Park Non-Fiction"
     },
@@ -25864,6 +26274,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpy01",
       "skos:prefLabel": "Clason's Point YA Reference"
     },
@@ -25888,14 +26299,17 @@
       "skos:prefLabel": "Seward Park Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:ctzzz",
+      "@id": "nyplLocation:mma33",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ct"
+        "@id": "nyplLocation:mm"
       },
-      "nypl:actualLocation": "Castle Hill (error code)",
-      "skos:notation": "ctzzz",
-      "skos:prefLabel": "Castle Hill (error code)"
+      "nypl:actualLocation": "Mid-Manhattan Closed Shelf Reference Third Floor",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "skos:notation": "mma33",
+      "skos:prefLabel": "Mid-Manhattan Closed Shelf Reference Third Floor"
     },
     {
       "@id": "nyplLocation:sej0f",
@@ -25918,14 +26332,15 @@
       "skos:prefLabel": "Throg's Neck Children"
     },
     {
-      "@id": "nyplLocation:hfa0f",
+      "@id": "nyplLocation:ctzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hf"
+        "@id": "nyplLocation:ct"
       },
-      "nypl:actualLocation": "Hamilton Fish Park Fiction",
-      "skos:notation": "hfa0f",
-      "skos:prefLabel": "Hamilton Fish Park Fiction"
+      "nypl:actualLocation": "Castle Hill (error code)",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "ctzzz",
+      "skos:prefLabel": "Castle Hill (error code)"
     },
     {
       "@id": "nyplLocation:nbj0l",
@@ -25938,14 +26353,15 @@
       "skos:prefLabel": "West New Brighton Children's World Languages"
     },
     {
-      "@id": "nyplLocation:stj0a",
+      "@id": "nyplLocation:cpy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:st"
+        "@id": "nyplLocation:cp"
       },
-      "nypl:actualLocation": "Stapleton Children's Easy Book",
-      "skos:notation": "stj0a",
-      "skos:prefLabel": "Stapleton Children's Easy Book"
+      "nypl:actualLocation": "Clason's Point YA Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cpy0f",
+      "skos:prefLabel": "Clason's Point YA Fiction"
     },
     {
       "@id": "nyplLocation:stj0f",
@@ -25964,6 +26380,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpy0l",
       "skos:prefLabel": "Clason's Point YA World Languages"
     },
@@ -26004,6 +26421,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa01",
       "skos:prefLabel": "Hamilton Fish Park Reference"
     },
@@ -26024,6 +26442,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa03",
       "skos:prefLabel": "Hamilton Fish Park Closed Shelf Reference"
     },
@@ -26044,6 +26463,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpy0v",
       "skos:prefLabel": "Clason's Point YA Non-Print Media"
     },
@@ -26076,6 +26496,26 @@
       "nypl:actualLocation": "Stapleton Children's Young Reader",
       "skos:notation": "stj0y",
       "skos:prefLabel": "Stapleton Children's Young Reader"
+    },
+    {
+      "@id": "nyplLocation:woa0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wo"
+      },
+      "nypl:actualLocation": "Woodstock Non-Print Media",
+      "skos:notation": "woa0v",
+      "skos:prefLabel": "Woodstock Non-Print Media"
+    },
+    {
+      "@id": "nyplLocation:kba03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:kb"
+      },
+      "nypl:actualLocation": "Kingsbridge Closed Shelf Reference",
+      "skos:notation": "kba03",
+      "skos:prefLabel": "Kingsbridge Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:maff1",
@@ -26128,14 +26568,14 @@
       "skos:prefLabel": "Woodlawn Heights Children's Reference"
     },
     {
-      "@id": "nyplLocation:ota0f",
+      "@id": "nyplLocation:sga0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:sg"
       },
-      "nypl:actualLocation": "Ottendorfer Fiction",
-      "skos:notation": "ota0f",
-      "skos:prefLabel": "Ottendorfer Fiction"
+      "nypl:actualLocation": "St. George Center for Reading & Writing",
+      "skos:notation": "sga0w",
+      "skos:prefLabel": "St. George Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:ssy0n",
@@ -26154,6 +26594,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxyr",
       "skos:prefLabel": "Francis Martin Young Adult Reference"
     },
@@ -26164,18 +26605,9 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya0v",
       "skos:prefLabel": "Spuyten Duyvil Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:cpy0f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
-      },
-      "nypl:actualLocation": "Clason's Point YA Fiction",
-      "skos:notation": "cpy0f",
-      "skos:prefLabel": "Clason's Point YA Fiction"
     },
     {
       "@id": "nyplLocation:tsyr",
@@ -26196,7 +26628,16 @@
       "nypl:actualLocation": "Schwarzman Building - Art & Architecture Rm 300 (BPSE)",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:mab"
@@ -26205,25 +26646,16 @@
           "@id": "nyplLocation:maf"
         },
         {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mal"
         }
       ],
       "nypl:owner": {
@@ -26231,7 +26663,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mab82",
       "skos:prefLabel": "SASB M1 - Art & Architecture Rm 300"
@@ -26243,6 +26675,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0t",
       "skos:prefLabel": "Battery Park Children's Fairy Tale"
     },
@@ -26273,6 +26706,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya0f",
       "skos:prefLabel": "Spuyten Duyvil Fiction"
     },
@@ -26283,6 +26717,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta01",
       "skos:prefLabel": "Castle Hill Reference"
     },
@@ -26293,6 +26728,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta03",
       "skos:prefLabel": "Castle Hill Closed Shelf Reference"
     },
@@ -26333,6 +26769,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0h",
       "skos:prefLabel": "Battery Park Children's Holiday Book"
     },
@@ -26353,6 +26790,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga03",
       "skos:prefLabel": "Aguilar Closed Shelf Reference"
     },
@@ -26363,6 +26801,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga01",
       "skos:prefLabel": "Aguilar Reference"
     },
@@ -26373,6 +26812,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0i",
       "skos:prefLabel": "Battery Park Children's Picture Book"
     },
@@ -26393,6 +26833,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcyr",
       "skos:prefLabel": "Bronx Library Center Young Adult Reference"
     },
@@ -26413,6 +26854,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyjr",
       "skos:prefLabel": "Spuyten Duyvil Children's Reference"
     },
@@ -26433,6 +26875,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya01",
       "skos:prefLabel": "Spuyten Duyvil Reference"
     },
@@ -26443,6 +26886,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aljr",
       "skos:prefLabel": "Allerton Children's Reference"
     },
@@ -26453,6 +26897,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya03",
       "skos:prefLabel": "Spuyten Duyvil Closed Shelf Reference"
     },
@@ -26473,6 +26918,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfy",
       "skos:prefLabel": "Hamilton Fish Park Young Adult"
     },
@@ -26493,6 +26939,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btj0a",
       "skos:prefLabel": "Battery Park Children's Easy Book"
     },
@@ -26513,6 +26960,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta0v",
       "skos:prefLabel": "Castle Hill Non-Print Media"
     },
@@ -26522,6 +26970,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ct"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta0w",
       "skos:prefLabel": "Castle Hill Adult Learning Center"
     },
@@ -26542,6 +26991,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga0n",
       "skos:prefLabel": "Aguilar Non-Fiction"
     },
@@ -26565,6 +27015,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga0l",
       "skos:prefLabel": "Aguilar World Languages"
     },
@@ -26585,6 +27036,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Center for Reading & Writing",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga0w",
       "skos:prefLabel": "Aguilar Center for Reading & Writing"
     },
@@ -26595,6 +27047,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga0v",
       "skos:prefLabel": "Aguilar Non-Print Media"
     },
@@ -26605,6 +27058,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta0f",
       "skos:prefLabel": "Castle Hill Fiction"
     },
@@ -26617,34 +27071,34 @@
       "nypl:actualLocation": "Schwarzman Building - Milstein Division Rm 121",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:malw"
         },
         {
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
           "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:map"
         },
         {
           "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:maln"
-        },
-        {
           "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mai"
         }
       ],
       "nypl:owner": {
@@ -26652,7 +27106,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mag82",
       "skos:prefLabel": "SASB M1 - Milstein Division Rm 121"
@@ -26684,6 +27138,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta0l",
       "skos:prefLabel": "Castle Hill World Languages"
     },
@@ -26694,6 +27149,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cta0n",
       "skos:prefLabel": "Castle Hill Non-Fiction"
     },
@@ -26724,6 +27180,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fey01",
       "skos:prefLabel": "58th Street YA Reference"
     },
@@ -26864,6 +27321,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyy",
       "skos:prefLabel": "Spuyten Duyvil Young Adult"
     },
@@ -26904,6 +27362,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty01",
       "skos:prefLabel": "Battery Park YA Reference"
     },
@@ -26914,6 +27373,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dyj",
       "skos:prefLabel": "Spuyten Duyvil Children"
     },
@@ -26964,6 +27424,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya",
       "skos:prefLabel": "Spuyten Duyvil Adult"
     },
@@ -26984,6 +27445,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpy0n",
       "skos:prefLabel": "Clason's Point YA Non-Fiction"
     },
@@ -27034,6 +27496,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fey0v",
       "skos:prefLabel": "58th Street YA Non-Print Media"
     },
@@ -27054,16 +27517,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Recorded Sound",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1124"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myh22",
       "skos:prefLabel": "Performing Arts Research Collections - Recorded Sound"
@@ -27075,16 +27538,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Recorded Sound - 2nd Floor Reference",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1124"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myh23",
       "skos:prefLabel": "Performing Arts Research Collections - Recorded Sound - 2nd Floor"
@@ -27126,6 +27589,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fey0f",
       "skos:prefLabel": "58th Street YA Fiction"
     },
@@ -27166,6 +27630,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fey0n",
       "skos:prefLabel": "58th Street YA Non-Fiction"
     },
@@ -27176,6 +27641,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fey0l",
       "skos:prefLabel": "58th Street YA World Languages"
     },
@@ -27209,6 +27675,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csyr",
       "skos:prefLabel": "Columbus Young Adult Reference"
     },
@@ -27223,22 +27690,13 @@
       "skos:prefLabel": "Webster Reference"
     },
     {
-      "@id": "nyplLocation:wtj0t",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
-      },
-      "nypl:actualLocation": "Westchester Square Children's Fairy Tale",
-      "skos:notation": "wtj0t",
-      "skos:prefLabel": "Westchester Square Children's Fairy Tale"
-    },
-    {
       "@id": "nyplLocation:bty0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty0f",
       "skos:prefLabel": "Battery Park YA Fiction"
     },
@@ -27269,6 +27727,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty0l",
       "skos:prefLabel": "Battery Park YA World Languages"
     },
@@ -27279,6 +27738,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty0n",
       "skos:prefLabel": "Battery Park YA Non-Fiction"
     },
@@ -27293,22 +27753,13 @@
       "skos:prefLabel": "Kips Bay Non-Print Media"
     },
     {
-      "@id": "nyplLocation:yvjr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:yv"
-      },
-      "nypl:actualLocation": "Yorkville Children's Reference",
-      "skos:notation": "yvjr",
-      "skos:prefLabel": "Yorkville Children's Reference"
-    },
-    {
       "@id": "nyplLocation:agj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0v",
       "skos:prefLabel": "Aguilar Children's Non-Print Media"
     },
@@ -27319,6 +27770,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bty0v",
       "skos:prefLabel": "Battery Park YA Non-Print Media"
     },
@@ -27329,6 +27781,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cly0v",
       "skos:prefLabel": "Morningside Heights YA Non-Print Media"
     },
@@ -27359,9 +27812,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "SASB - Wertheim Scholar Room",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:malw"
       },
+      "nypl:deliveryLocationType": "Scholar",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -27452,6 +27907,7 @@
         "@id": "nyplLocation:fw"
       },
       "nypl:actualLocation": "Fort Washington Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fwar",
       "skos:prefLabel": "Fort Washington Adult Reference"
     },
@@ -27462,6 +27918,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcyr",
       "skos:prefLabel": "Grand Central Young Adult Reference"
     },
@@ -27496,7 +27953,13 @@
           "@id": "nyplLocation:map"
         },
         {
+          "@id": "nyplLocation:mal"
+        },
+        {
           "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:maf"
@@ -27505,22 +27968,16 @@
           "@id": "nyplLocation:mab"
         },
         {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:malw"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:mag"
         }
       ],
       "nypl:owner": {
@@ -27528,7 +27985,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "maj92",
       "skos:prefLabel": "SASB M2 - General Research - Room 315"
@@ -27587,21 +28044,13 @@
       "skos:prefLabel": "Yorkville Fiction"
     },
     {
-      "@id": "nyplLocation:ma0b",
-      "@type": "nypl:Location",
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/NK"
-      },
-      "skos:notation": "ma0b",
-      "skos:prefLabel": ""
-    },
-    {
       "@id": "nyplLocation:btar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "btar",
       "skos:prefLabel": "Battery Park Adult Reference"
     },
@@ -27642,6 +28091,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpyr",
       "skos:prefLabel": "Clason's Point Young Adult Reference"
     },
@@ -27840,12 +28290,26 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts - Reserve Film and Video",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": [
+        "Research",
+        "Branch"
+      ],
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myrfv"
+      },
+      "nypl:deliveryLocationType": [
+        "Branch",
+        "Research"
+      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NN"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
       "skos:notation": "myrfv",
       "skos:prefLabel": "Performing Arts - Reserve Film and Video"
@@ -27881,14 +28345,29 @@
       "skos:prefLabel": "Melrose Fiction"
     },
     {
-      "@id": "nyplLocation:sezzz",
+      "@id": "nyplLocation:malc",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:ma"
       },
-      "nypl:actualLocation": "Seward Park (error code)",
-      "skos:notation": "sezzz",
-      "skos:prefLabel": "Seward Park (error code)"
+      "nypl:actualLocation": "SASB - Cullman Center",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:malc"
+      },
+      "nypl:deliveryLocationType": "Scholar",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1127"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "malc",
+      "skos:prefLabel": "SASB - Cullman Center"
     },
     {
       "@id": "nyplLocation:mea0l",
@@ -27911,38 +28390,17 @@
       "skos:prefLabel": "Melrose Non-Fiction"
     },
     {
-      "@id": "nyplLocation:malc",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
-      },
-      "nypl:actualLocation": "SASB - Cullman Center",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mala"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1127"
-      },
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/OC"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:notation": "malc",
-      "skos:prefLabel": "SASB - Cullman Center"
-    },
-    {
       "@id": "nyplLocation:mala",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "SASB - Allen Scholar Room",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:mala"
       },
+      "nypl:deliveryLocationType": "Scholar",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -27963,6 +28421,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ag",
       "skos:prefLabel": "Aguilar"
     },
@@ -27973,6 +28432,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewyr",
       "skos:prefLabel": "Edenwald Young Adult Reference"
     },
@@ -27983,6 +28443,7 @@
         "@id": "nyplLocation:al"
       },
       "nypl:actualLocation": "Allerton",
+      "nypl:collectionType": "Branch",
       "skos:notation": "al",
       "skos:prefLabel": "Allerton"
     },
@@ -28013,9 +28474,11 @@
         "@id": "nyplLocation:ma"
       },
       "nypl:actualLocation": "SASB - Noma Scholar Room",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:maln"
       },
+      "nypl:deliveryLocationType": "Scholar",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -28090,16 +28553,6 @@
       "skos:prefLabel": "Muhlenberg YA Fiction"
     },
     {
-      "@id": "nyplLocation:pkj",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
-      },
-      "nypl:actualLocation": "Parkchester Children",
-      "skos:notation": "pkj",
-      "skos:prefLabel": "Parkchester Children"
-    },
-    {
       "@id": "nyplLocation:muy0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -28135,8 +28588,16 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:Ma"
       },
+      "nypl:actualLocation": "Schwarzman Building - Rare Book Collection Rm 328",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:mar"
+      },
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1108"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
       },
       "skos:notation": "mar92",
       "skos:prefLabel": "SASB - Rare Books Division - Room 324"
@@ -28206,7 +28667,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "scff2",
       "skos:prefLabel": "Schomburg Center - Research & Reference"
@@ -28226,7 +28687,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "scff3",
       "skos:prefLabel": "Schomburg Center - Research & Reference - Desk"
@@ -28258,6 +28719,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills Young Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkyr",
       "skos:prefLabel": "Great Kills Young Adult Reference"
     },
@@ -28288,6 +28750,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj",
       "skos:prefLabel": "Grand Central Children"
     },
@@ -28302,12 +28765,24 @@
       "skos:prefLabel": "Roosevelt Island (error code)"
     },
     {
+      "@id": "nyplLocation:eaj0i",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ea"
+      },
+      "nypl:actualLocation": "Eastchester Children's Picture Book",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "eaj0i",
+      "skos:prefLabel": "Eastchester Children's Picture Book"
+    },
+    {
       "@id": "nyplLocation:gca",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gca",
       "skos:prefLabel": "Grand Central Adult"
     },
@@ -28348,6 +28823,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcy",
       "skos:prefLabel": "Grand Central Young Adult"
     },
@@ -28368,6 +28844,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epj0f",
       "skos:prefLabel": "Epiphany Children's Fiction"
     },
@@ -28538,6 +29015,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcjr",
       "skos:prefLabel": "Bronx Library Center Children's Reference"
     },
@@ -28558,6 +29036,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epar",
       "skos:prefLabel": "Epiphany Adult Reference"
     },
@@ -28608,7 +29087,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Recorded Media Reference",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -28622,7 +29101,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Recorded Media Reference",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -28673,7 +29152,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myrs",
       "skos:prefLabel": "Performing Arts - Special Collections Desk - 3rd Fl"
@@ -28695,6 +29174,7 @@
         "@id": "nyplLocation:cl"
       },
       "nypl:actualLocation": "Morningside Heights Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cly",
       "skos:prefLabel": "Morningside Heights Young Adult"
     },
@@ -28739,16 +29219,6 @@
       "skos:prefLabel": "South Beach (error code)"
     },
     {
-      "@id": "nyplLocation:nbj0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
-      },
-      "nypl:actualLocation": "West New Brighton Children's Non-Fiction",
-      "skos:notation": "nbj0n",
-      "skos:prefLabel": "West New Brighton Children's Non-Fiction"
-    },
-    {
       "@id": "nyplLocation:tg",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -28769,16 +29239,6 @@
       "skos:prefLabel": "Todt Hill-Westerleigh Children"
     },
     {
-      "@id": "nyplLocation:brj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:br"
-      },
-      "nypl:actualLocation": "George Bruce Children's Non-Print Media",
-      "skos:notation": "brj0v",
-      "skos:prefLabel": "George Bruce Children's Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:mab92",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -28786,31 +29246,31 @@
       },
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:malw"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:mab"
         },
         {
-          "@id": "nyplLocation:maf"
+          "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:mal"
         },
         {
           "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mai"
         },
         {
           "@id": "nyplLocation:malc"
@@ -28821,7 +29281,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mab92",
       "skos:prefLabel": "SASB M2 - Art and Architecture - Room 300"
@@ -28843,6 +29303,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bajr",
       "skos:prefLabel": "Baychester Children's Reference"
     },
@@ -28900,6 +29361,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ft"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "ftar",
       "skos:prefLabel": "53rd Street Adult Reference"
     },
@@ -29000,6 +29462,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaa",
       "skos:prefLabel": "Eastchester Adult"
     },
@@ -29010,6 +29473,7 @@
         "@id": "nyplLocation:dy"
       },
       "nypl:actualLocation": "Spuyten Duyvil World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dya0l",
       "skos:prefLabel": "Spuyten Duyvil World Languages"
     },
@@ -29040,6 +29504,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0a",
       "skos:prefLabel": "Dongan Hills Children's Easy Book"
     },
@@ -29090,6 +29555,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0h",
       "skos:prefLabel": "Dongan Hills Children's Holiday Book"
     },
@@ -29100,6 +29566,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0i",
       "skos:prefLabel": "Dongan Hills Children's Picture Book"
     },
@@ -29130,6 +29597,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0l",
       "skos:prefLabel": "Dongan Hills Children's World Languages"
     },
@@ -29150,6 +29618,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewzzz",
       "skos:prefLabel": "Edenwald (error code)"
     },
@@ -29170,18 +29639,20 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0t",
       "skos:prefLabel": "Dongan Hills Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:dhj0v",
+      "@id": "nyplLocation:eaar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:ea"
       },
-      "nypl:actualLocation": "Dongan Hills Children's Non-Print Media",
-      "skos:notation": "dhj0v",
-      "skos:prefLabel": "Dongan Hills Children's Non-Print Media"
+      "nypl:actualLocation": "Eastchester Adult Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "eaar",
+      "skos:prefLabel": "Eastchester Adult Reference"
     },
     {
       "@id": "nyplLocation:mlyr",
@@ -29200,6 +29671,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj0y",
       "skos:prefLabel": "Dongan Hills Children's Young Reader"
     },
@@ -29210,29 +29682,36 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Music",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1123"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mym32",
       "skos:prefLabel": "Performing Arts Research Collections - Music"
     },
     {
-      "@id": "nyplLocation:ewj",
+      "@id": "nyplLocation:sl",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ew"
+        "@id": "nyplLocation:sl"
       },
-      "nypl:actualLocation": "Edenwald Children",
-      "skos:notation": "ewj",
-      "skos:prefLabel": "Edenwald Children"
+      "nypl:actualLocation": "SIBL - Science Industry and Business",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1125"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "sl",
+      "skos:prefLabel": "SIBL - Science Industry and Business"
     },
     {
       "@id": "nyplLocation:hgj01",
@@ -29251,6 +29730,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfar",
       "skos:prefLabel": "Hamilton Fish Park Adult Reference"
     },
@@ -29271,6 +29751,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba01",
       "skos:prefLabel": "High Bridge Reference"
     },
@@ -29281,6 +29762,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba03",
       "skos:prefLabel": "High Bridge Closed Shelf Reference"
     },
@@ -29316,31 +29798,31 @@
           "@id": "nyplLocation:mab"
         },
         {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:malw"
         },
         {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:maf"
         },
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mal"
         }
       ],
       "nypl:owner": {
@@ -29354,12 +29836,23 @@
       "skos:prefLabel": "OFFSITE - TSD - Request in Advance for use at Schwarzman Bldg"
     },
     {
+      "@id": "nyplLocation:rty0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:rt"
+      },
+      "nypl:actualLocation": "Richmondtown YA Non-Print Media",
+      "skos:notation": "rty0v",
+      "skos:prefLabel": "Richmondtown YA Non-Print Media"
+    },
+    {
       "@id": "nyplLocation:agj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0n",
       "skos:prefLabel": "Aguilar Children's Non-Fiction"
     },
@@ -29370,6 +29863,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewa",
       "skos:prefLabel": "Edenwald Adult"
     },
@@ -29380,6 +29874,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfa0l",
       "skos:prefLabel": "Hamilton Fish Park World Languages"
     },
@@ -29390,6 +29885,7 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhj01",
       "skos:prefLabel": "Dongan Hills Children's Reference"
     },
@@ -29422,40 +29918,40 @@
       "nypl:actualLocation": "OFFSITE - TSD - Request in Advance",
       "nypl:deliverableTo": [
         {
+          "@id": "nyplLocation:mai"
+        },
+        {
           "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:maf"
+          "@id": "nyplLocation:map"
         },
         {
           "@id": "nyplLocation:slr"
         },
         {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
           "@id": "nyplLocation:malc"
         },
         {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:mab"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:sc"
@@ -29498,6 +29994,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba0l",
       "skos:prefLabel": "High Bridge World Languages"
     },
@@ -29508,6 +30005,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba0n",
       "skos:prefLabel": "High Bridge Non-Fiction"
     },
@@ -29605,21 +30103,20 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:hb"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "hba0w",
       "skos:prefLabel": "High Bridge Adult Learning Center"
     },
     {
-      "@id": "nyplLocation:mma0f",
+      "@id": "nyplLocation:hba0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mm"
+        "@id": "nyplLocation:hb"
       },
-      "nypl:actualLocation": "Mid-Manhattan Fiction First Floor",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1500"
-      },
-      "skos:notation": "mma0f",
-      "skos:prefLabel": "Mid-Manhattan Fiction First Floor"
+      "nypl:actualLocation": "High Bridge Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hba0v",
+      "skos:prefLabel": "High Bridge Non-Print Media"
     },
     {
       "@id": "nyplLocation:sgzzz",
@@ -29648,16 +30145,16 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Research Collections - Recorded Sound",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
       },
-      "nypl:locationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1124"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "myh32",
       "skos:prefLabel": "Performing Arts Research Collections - Recorded Sound"
@@ -29729,6 +30226,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly0v",
       "skos:prefLabel": "Bloomingdale YA Non-Print Media"
     },
@@ -29743,14 +30241,14 @@
       "skos:prefLabel": "Seward Park YA Fiction"
     },
     {
-      "@id": "nyplLocation:chyr",
+      "@id": "nyplLocation:sv",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ch"
+        "@id": "nyplLocation:sv"
       },
-      "nypl:actualLocation": "Chatham Square Young Adult Reference",
-      "skos:notation": "chyr",
-      "skos:prefLabel": "Chatham Square Young Adult Reference"
+      "nypl:actualLocation": "Soundview",
+      "skos:notation": "sv",
+      "skos:prefLabel": "Soundview"
     },
     {
       "@id": "nyplLocation:sey0n",
@@ -29809,6 +30307,7 @@
         "@id": "nyplLocation:gk"
       },
       "nypl:actualLocation": "Great Kills (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gkzzz",
       "skos:prefLabel": "Great Kills (error code)"
     },
@@ -29819,6 +30318,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point (error code)",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpzzz",
       "skos:prefLabel": "Clason's Point (error code)"
     },
@@ -29829,8 +30329,19 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly0n",
       "skos:prefLabel": "Bloomingdale YA Non-Fiction"
+    },
+    {
+      "@id": "nyplLocation:pry0l",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:pr"
+      },
+      "nypl:actualLocation": "Port Richmond YA World Languages",
+      "skos:notation": "pry0l",
+      "skos:prefLabel": "Port Richmond YA World Languages"
     },
     {
       "@id": "nyplLocation:tsjr",
@@ -29878,6 +30389,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agj0t",
       "skos:prefLabel": "Aguilar Children's Fairy Tale"
     },
@@ -29888,6 +30400,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0v",
       "skos:prefLabel": "Grand Central Children's Non-Print Media"
     },
@@ -29908,6 +30421,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0t",
       "skos:prefLabel": "Grand Central Children's Fairy Tale"
     },
@@ -29918,6 +30432,7 @@
         "@id": "nyplLocation:ca"
       },
       "nypl:actualLocation": "Terence Cardinal Cooke-Cathedral Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "caj",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children"
     },
@@ -29930,16 +30445,6 @@
       "nypl:actualLocation": "Jerome Park Young Adult Reference",
       "skos:notation": "jpyr",
       "skos:prefLabel": "Jerome Park Young Adult Reference"
-    },
-    {
-      "@id": "nyplLocation:agj0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ag"
-      },
-      "nypl:actualLocation": "Aguilar Children's World Languages",
-      "skos:notation": "agj0l",
-      "skos:prefLabel": "Aguilar Children's World Languages"
     },
     {
       "@id": "nyplLocation:woar",
@@ -29968,6 +30473,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0y",
       "skos:prefLabel": "Grand Central Children's Young Reader"
     },
@@ -29978,6 +30484,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0f",
       "skos:prefLabel": "Grand Central Children's Fiction"
     },
@@ -29998,18 +30505,20 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0a",
       "skos:prefLabel": "Grand Central Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:pk",
+      "@id": "nyplLocation:gcj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:gc"
       },
-      "nypl:actualLocation": "Parkchester",
-      "skos:notation": "pk",
-      "skos:prefLabel": "Parkchester"
+      "nypl:actualLocation": "Grand Central Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "gcj0n",
+      "skos:prefLabel": "Grand Central Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:fea03",
@@ -30018,6 +30527,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fea03",
       "skos:prefLabel": "58th Street Closed Shelf Reference"
     },
@@ -30028,18 +30538,20 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0l",
       "skos:prefLabel": "Grand Central Children's World Languages"
     },
     {
-      "@id": "nyplLocation:jpj0y",
+      "@id": "nyplLocation:fea01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:jp"
+        "@id": "nyplLocation:fe"
       },
-      "nypl:actualLocation": "Jerome Park Children's Young Reader",
-      "skos:notation": "jpj0y",
-      "skos:prefLabel": "Jerome Park Children's Young Reader"
+      "nypl:actualLocation": "58th Street Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "fea01",
+      "skos:prefLabel": "58th Street Reference"
     },
     {
       "@id": "nyplLocation:gcj0h",
@@ -30048,18 +30560,32 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj0h",
       "skos:prefLabel": "Grand Central Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:gcj0i",
+      "@id": "nyplLocation:jmjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gc"
+        "@id": "nyplLocation:jm"
       },
-      "nypl:actualLocation": "Grand Central Children's Picture Book",
-      "skos:notation": "gcj0i",
-      "skos:prefLabel": "Grand Central Children's Picture Book"
+      "nypl:actualLocation": "Jefferson Market Children's Reference",
+      "skos:notation": "jmjr",
+      "skos:prefLabel": "Jefferson Market Children's Reference"
+    },
+    {
+      "@id": "nyplLocation:mma0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:actualLocation": "Mid-Manhattan Fiction First Floor",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "skos:notation": "mma0f",
+      "skos:prefLabel": "Mid-Manhattan Fiction First Floor"
     },
     {
       "@id": "nyplLocation:hkjr",
@@ -30078,6 +30604,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0l",
       "skos:prefLabel": "Bronx Library Center Children's World Languages"
     },
@@ -30088,6 +30615,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fea0n",
       "skos:prefLabel": "58th Street Non-Fiction"
     },
@@ -30098,6 +30626,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fea0l",
       "skos:prefLabel": "58th Street World Languages"
     },
@@ -30108,6 +30637,7 @@
         "@id": "nyplLocation:gc"
       },
       "nypl:actualLocation": "Grand Central Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "gcj01",
       "skos:prefLabel": "Grand Central Children's Reference"
     },
@@ -30128,6 +30658,7 @@
         "@id": "nyplLocation:fe"
       },
       "nypl:actualLocation": "58th Street Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fea0f",
       "skos:prefLabel": "58th Street Fiction"
     },
@@ -30172,14 +30703,15 @@
       "skos:prefLabel": "Kips Bay YA Fiction"
     },
     {
-      "@id": "nyplLocation:fea0v",
+      "@id": "nyplLocation:hfa0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:hf"
       },
-      "nypl:actualLocation": "58th Street Non-Print Media",
-      "skos:notation": "fea0v",
-      "skos:prefLabel": "58th Street Non-Print Media"
+      "nypl:actualLocation": "Hamilton Fish Park Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hfa0f",
+      "skos:prefLabel": "Hamilton Fish Park Fiction"
     },
     {
       "@id": "nyplLocation:mmy2f",
@@ -30195,14 +30727,14 @@
       "skos:prefLabel": "Mid-Manhattan Young Adult Fiction Second Floor"
     },
     {
-      "@id": "nyplLocation:woa0l",
+      "@id": "nyplLocation:hgy01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wo"
+        "@id": "nyplLocation:hg"
       },
-      "nypl:actualLocation": "Woodstock World Languages",
-      "skos:notation": "woa0l",
-      "skos:prefLabel": "Woodstock World Languages"
+      "nypl:actualLocation": "Hamilton Grange YA Reference",
+      "skos:notation": "hgy01",
+      "skos:prefLabel": "Hamilton Grange YA Reference"
     },
     {
       "@id": "nyplLocation:bta0l",
@@ -30211,6 +30743,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta0l",
       "skos:prefLabel": "Battery Park World Languages"
     },
@@ -30221,6 +30754,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta0n",
       "skos:prefLabel": "Battery Park Non-Fiction"
     },
@@ -30231,6 +30765,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj0t",
       "skos:prefLabel": "Bronx Library Center Children's Fairy Tale"
     },
@@ -30241,28 +30776,31 @@
         "@id": "nyplLocation:dh"
       },
       "nypl:actualLocation": "Dongan Hills YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "dhy0f",
       "skos:prefLabel": "Dongan Hills YA Fiction"
     },
     {
-      "@id": "nyplLocation:bta0f",
+      "@id": "nyplLocation:cpa03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:bt"
+        "@id": "nyplLocation:cp"
       },
-      "nypl:actualLocation": "Battery Park Fiction",
-      "skos:notation": "bta0f",
-      "skos:prefLabel": "Battery Park Fiction"
+      "nypl:actualLocation": "Clason's Point Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "cpa03",
+      "skos:prefLabel": "Clason's Point Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:brjr",
+      "@id": "nyplLocation:dhy0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:br"
+        "@id": "nyplLocation:dh"
       },
-      "nypl:actualLocation": "George Bruce Children's Reference",
-      "skos:notation": "brjr",
-      "skos:prefLabel": "George Bruce Children's Reference"
+      "nypl:actualLocation": "Dongan Hills YA Non-Print Media",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "dhy0v",
+      "skos:prefLabel": "Dongan Hills YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:bta0v",
@@ -30271,6 +30809,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta0v",
       "skos:prefLabel": "Battery Park Non-Print Media"
     },
@@ -30281,6 +30820,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0n",
       "skos:prefLabel": "Eastchester Children's Non-Fiction"
     },
@@ -30291,6 +30831,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0l",
       "skos:prefLabel": "Eastchester Children's World Languages"
     },
@@ -30301,6 +30842,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0h",
       "skos:prefLabel": "Eastchester Children's Holiday Book"
     },
@@ -30311,6 +30853,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy0f",
       "skos:prefLabel": "Columbus YA Fiction"
     },
@@ -30321,6 +30864,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0f",
       "skos:prefLabel": "Eastchester Children's Fiction"
     },
@@ -30341,6 +30885,7 @@
         "@id": "nyplLocation:hb"
       },
       "nypl:actualLocation": "High Bridge Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hbjr",
       "skos:prefLabel": "High Bridge Children's Reference"
     },
@@ -30351,6 +30896,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy0l",
       "skos:prefLabel": "Columbus YA World Languages"
     },
@@ -30361,6 +30907,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy0n",
       "skos:prefLabel": "Columbus YA Non-Fiction"
     },
@@ -30381,6 +30928,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bcj",
       "skos:prefLabel": "Bronx Library Center Children"
     },
@@ -30391,6 +30939,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy0v",
       "skos:prefLabel": "Columbus YA Non-Print Media"
     },
@@ -30401,6 +30950,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0v",
       "skos:prefLabel": "Eastchester Children's Non-Print Media"
     },
@@ -30421,6 +30971,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj0t",
       "skos:prefLabel": "Eastchester Children's Fairy Tale"
     },
@@ -30441,6 +30992,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "baa01",
       "skos:prefLabel": "Baychester Reference"
     },
@@ -30451,6 +31003,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park City",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bt",
       "skos:prefLabel": "Battery Park City"
     },
@@ -30461,6 +31014,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa0v",
       "skos:prefLabel": "Clason's Point Non-Print Media"
     },
@@ -30470,6 +31024,7 @@
       "dcterms:isPartOf": {
         "@id": "nyplLocation:cp"
       },
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa0w",
       "skos:prefLabel": "Clason's Point Adult Learning Center"
     },
@@ -30480,6 +31035,7 @@
         "@id": "nyplLocation:br"
       },
       "nypl:actualLocation": "George Bruce",
+      "nypl:collectionType": "Branch",
       "skos:notation": "br",
       "skos:prefLabel": "George Bruce"
     },
@@ -30490,6 +31046,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa0l",
       "skos:prefLabel": "Clason's Point World Languages"
     },
@@ -30500,6 +31057,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bl",
       "skos:prefLabel": "Bloomingdale"
     },
@@ -30510,6 +31068,7 @@
         "@id": "nyplLocation:cp"
       },
       "nypl:actualLocation": "Clason's Point Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cpa0n",
       "skos:prefLabel": "Clason's Point Non-Fiction"
     },
@@ -30530,6 +31089,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta01",
       "skos:prefLabel": "Battery Park Reference"
     },
@@ -30540,6 +31100,7 @@
         "@id": "nyplLocation:bt"
       },
       "nypl:actualLocation": "Battery Park Closed Shelf Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bta03",
       "skos:prefLabel": "Battery Park Closed Shelf Reference"
     },
@@ -30550,6 +31111,7 @@
         "@id": "nyplLocation:ba"
       },
       "nypl:actualLocation": "Baychester",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ba",
       "skos:prefLabel": "Baychester"
     },
@@ -30570,6 +31132,7 @@
         "@id": "nyplLocation:bc"
       },
       "nypl:actualLocation": "Bronx Library Center",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bc",
       "skos:prefLabel": "Bronx Library Center"
     },
@@ -30580,6 +31143,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "aga0f",
       "skos:prefLabel": "Aguilar Fiction"
     },
@@ -30590,6 +31154,7 @@
         "@id": "nyplLocation:cs"
       },
       "nypl:actualLocation": "Columbus YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "csy01",
       "skos:prefLabel": "Columbus YA Reference"
     },
@@ -30600,6 +31165,7 @@
         "@id": "nyplLocation:bl"
       },
       "nypl:actualLocation": "Bloomingdale YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bly01",
       "skos:prefLabel": "Bloomingdale YA Reference"
     },
@@ -30610,6 +31176,7 @@
         "@id": "nyplLocation:ea"
       },
       "nypl:actualLocation": "Eastchester Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "eaj01",
       "skos:prefLabel": "Eastchester Children's Reference"
     },
@@ -30640,9 +31207,11 @@
         "@id": "nyplLocation:sc"
       },
       "nypl:actualLocation": "Schomburg Center - Moving Image & Recorded Sound",
+      "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
         "@id": "nyplLocation:sc"
       },
+      "nypl:deliveryLocationType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1117"
       },
@@ -30723,7 +31292,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts - Reserve Film and Video",
-      "nypl:locationType": "Branch",
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -30761,14 +31330,17 @@
       "skos:prefLabel": "Hunt's Point Children"
     },
     {
-      "@id": "nyplLocation:hdj0h",
+      "@id": "nyplLocation:slajn",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hd"
+        "@id": "nyplLocation:sl"
       },
-      "nypl:actualLocation": "125th Street Children's Holiday Book",
-      "skos:notation": "hdj0h",
-      "skos:prefLabel": "125th Street Children's Holiday Book"
+      "nypl:actualLocation": "SIBL - Job Search Central Non-Fiction",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1125"
+      },
+      "skos:notation": "slajn",
+      "skos:prefLabel": "SIBL - Job Search Central Non-Fiction"
     },
     {
       "@id": "nyplLocation:hfy0v",
@@ -30777,6 +31349,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfy0v",
       "skos:prefLabel": "Hamilton Fish Park YA Non-Print Media"
     },
@@ -30787,6 +31360,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty0l",
       "skos:prefLabel": "Castle Hill YA World Languages"
     },
@@ -30797,6 +31371,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty0n",
       "skos:prefLabel": "Castle Hill YA Non-Fiction"
     },
@@ -30830,6 +31405,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bey",
       "skos:prefLabel": "Belmont Young Adult"
     },
@@ -30845,31 +31421,31 @@
           "@id": "nyplLocation:malc"
         },
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
           "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:maf"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:mai"
         }
       ],
       "nypl:owner": {
@@ -30877,7 +31453,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "maf82",
       "skos:prefLabel": "SASB M1 - Dorot Jewish Division Rm 111"
@@ -30889,6 +31465,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill YA Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty0f",
       "skos:prefLabel": "Castle Hill YA Fiction"
     },
@@ -30899,7 +31476,7 @@
         "@id": "nyplLocation:my"
       },
       "nypl:actualLocation": "Performing Arts Library at Lincoln Center",
-      "nypl:locationType": "Both",
+      "nypl:collectionType": "Both",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
       },
@@ -30930,14 +31507,15 @@
       "skos:prefLabel": "Mid-Manhattan Non-Fiction Third Floor"
     },
     {
-      "@id": "nyplLocation:epy01",
+      "@id": "nyplLocation:hfy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ep"
+        "@id": "nyplLocation:hf"
       },
-      "nypl:actualLocation": "Epiphany YA Reference",
-      "skos:notation": "epy01",
-      "skos:prefLabel": "Epiphany YA Reference"
+      "nypl:actualLocation": "Hamilton Fish Park YA Fiction",
+      "nypl:collectionType": "Branch",
+      "skos:notation": "hfy0f",
+      "skos:prefLabel": "Hamilton Fish Park YA Fiction"
     },
     {
       "@id": "nyplLocation:bea",
@@ -30946,6 +31524,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bea",
       "skos:prefLabel": "Belmont Adult"
     },
@@ -30956,6 +31535,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfy0l",
       "skos:prefLabel": "Hamilton Fish Park YA World Languages"
     },
@@ -30966,6 +31546,7 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfy0n",
       "skos:prefLabel": "Hamilton Fish Park YA Non-Fiction"
     },
@@ -30986,6 +31567,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty0v",
       "skos:prefLabel": "Castle Hill YA Non-Print Media"
     },
@@ -30996,6 +31578,7 @@
         "@id": "nyplLocation:be"
       },
       "nypl:actualLocation": "Belmont Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "bej",
       "skos:prefLabel": "Belmont Children"
     },
@@ -31046,18 +31629,9 @@
         "@id": "nyplLocation:hf"
       },
       "nypl:actualLocation": "Hamilton Fish Park YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hfy01",
       "skos:prefLabel": "Hamilton Fish Park YA Reference"
-    },
-    {
-      "@id": "nyplLocation:tmj0y",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:tm"
-      },
-      "nypl:actualLocation": "Tremont Children's Young Reader",
-      "skos:notation": "tmj0y",
-      "skos:prefLabel": "Tremont Children's Young Reader"
     },
     {
       "@id": "nyplLocation:lbj0y",
@@ -31076,6 +31650,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany YA Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epy0n",
       "skos:prefLabel": "Epiphany YA Non-Fiction"
     },
@@ -31099,6 +31674,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany YA World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epy0l",
       "skos:prefLabel": "Epiphany YA World Languages"
     },
@@ -31119,6 +31695,7 @@
         "@id": "nyplLocation:ep"
       },
       "nypl:actualLocation": "Epiphany YA Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "epy0v",
       "skos:prefLabel": "Epiphany YA Non-Print Media"
     },
@@ -31149,6 +31726,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill YA Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cty01",
       "skos:prefLabel": "Castle Hill YA Reference"
     },
@@ -31338,6 +31916,11 @@
         "@id": "nyplLocation:ls"
       },
       "nypl:actualLocation": "Library Services Center - Special Formats Processing",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:lsdd2"
+      },
+      "nypl:deliveryLocationType": "Research",
       "nypl:recapCustomerCode": {
         "@id": "http://data.nypl.org/recapCustomerCodes/NI"
       },
@@ -31359,7 +31942,7 @@
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "skos:notation": "mabm2",
       "skos:prefLabel": "SASB - Art & Architecture Rm 300"
@@ -31371,6 +31954,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cia",
       "skos:prefLabel": "City Island Adult"
     },
@@ -31394,6 +31978,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "cij",
       "skos:prefLabel": "City Island Children"
     },
@@ -31424,47 +32009,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        }
-      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -31482,6 +32026,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdy",
       "skos:prefLabel": "125th Street Young Adult"
     },
@@ -31515,6 +32060,7 @@
         "@id": "nyplLocation:ci"
       },
       "nypl:actualLocation": "City Island Young Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ciy",
       "skos:prefLabel": "City Island Young Adult"
     },
@@ -31575,6 +32121,7 @@
         "@id": "nyplLocation:ag"
       },
       "nypl:actualLocation": "Aguilar Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "agar",
       "skos:prefLabel": "Aguilar Adult Reference"
     },
@@ -31595,6 +32142,7 @@
         "@id": "nyplLocation:ch"
       },
       "nypl:actualLocation": "Chatham Square Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "chjr",
       "skos:prefLabel": "Chatham Square Children's Reference"
     },
@@ -31619,6 +32167,16 @@
       "skos:prefLabel": "Webster YA Non-Print Media"
     },
     {
+      "@id": "nyplLocation:ota0n",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ot"
+      },
+      "nypl:actualLocation": "Ottendorfer Non-Fiction",
+      "skos:notation": "ota0n",
+      "skos:prefLabel": "Ottendorfer Non-Fiction"
+    },
+    {
       "@id": "nyplLocation:ria0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -31635,6 +32193,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Adult",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hda",
       "skos:prefLabel": "125th Street Adult"
     },
@@ -31715,6 +32274,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj01",
       "skos:prefLabel": "Francis Martin Children's Reference"
     },
@@ -31755,6 +32315,7 @@
         "@id": "nyplLocation:ct"
       },
       "nypl:actualLocation": "Castle Hill Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ctj0v",
       "skos:prefLabel": "Castle Hill Children's Non-Print Media"
     },
@@ -31765,6 +32326,7 @@
         "@id": "nyplLocation:hd"
       },
       "nypl:actualLocation": "125th Street Children",
+      "nypl:collectionType": "Branch",
       "skos:notation": "hdj",
       "skos:prefLabel": "125th Street Children"
     },
@@ -31898,6 +32460,7 @@
         "@id": "nyplLocation:ew"
       },
       "nypl:actualLocation": "Edenwald Adult Reference",
+      "nypl:collectionType": "Branch",
       "skos:notation": "ewar",
       "skos:prefLabel": "Edenwald Adult Reference"
     },
@@ -31938,6 +32501,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Non-Print Media",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0v",
       "skos:prefLabel": "Francis Martin Children's Non-Print Media"
     },
@@ -31948,6 +32512,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Fairy Tale",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0t",
       "skos:prefLabel": "Francis Martin Children's Fairy Tale"
     },
@@ -31958,9 +32523,6 @@
         "@id": "nyplLocation:rc"
       },
       "nypl:actualLocation": "OFFSITE - Request in Advance for use at Schwarzman Bldg",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mai"
-      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "true"
@@ -31975,6 +32537,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Young Reader",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0y",
       "skos:prefLabel": "Francis Martin Children's Young Reader"
     },
@@ -31985,6 +32548,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Easy Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0a",
       "skos:prefLabel": "Francis Martin Children's Easy Book"
     },
@@ -31995,6 +32559,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0f",
       "skos:prefLabel": "Francis Martin Children's Fiction"
     },
@@ -32025,6 +32590,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Holiday Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0h",
       "skos:prefLabel": "Francis Martin Children's Holiday Book"
     },
@@ -32035,6 +32601,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Picture Book",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0i",
       "skos:prefLabel": "Francis Martin Children's Picture Book"
     },
@@ -32045,6 +32612,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's Non-Fiction",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0n",
       "skos:prefLabel": "Francis Martin Children's Non-Fiction"
     },
@@ -32065,6 +32633,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin Children's World Languages",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fxj0l",
       "skos:prefLabel": "Francis Martin Children's World Languages"
     },
@@ -32085,6 +32654,7 @@
         "@id": "nyplLocation:fx"
       },
       "nypl:actualLocation": "Francis Martin",
+      "nypl:collectionType": "Branch",
       "skos:notation": "fx",
       "skos:prefLabel": "Francis Martin"
     },
@@ -32109,14 +32679,25 @@
       "skos:prefLabel": "Soundview YA Reference"
     },
     {
-      "@id": "nyplLocation:wla03",
+      "@id": "nyplLocation:mym42",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
+        "@id": "nyplLocation:my"
       },
-      "nypl:actualLocation": "Woodlawn Heights Closed Shelf Reference",
-      "skos:notation": "wla03",
-      "skos:prefLabel": "Woodlawn Heights Closed Shelf Reference"
+      "nypl:actualLocation": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:notation": "mym42",
+      "skos:prefLabel": "OFFSITE Rose - Request in advance for use at Performing Arts"
     }
   ]
 }

--- a/test/resources/recapCustomerCodes.json
+++ b/test/resources/recapCustomerCodes.json
@@ -108,37 +108,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         }
       ],
       "nypl:eddRequestable": {
@@ -224,37 +236,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NO"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         }
       ],
       "nypl:eddRequestable": {
@@ -272,37 +296,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NO"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NB"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
         }
       ],
       "nypl:eddRequestable": {
@@ -359,37 +395,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NF"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
         }
       ],
       "nypl:eddRequestable": {
@@ -455,34 +503,46 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/NB"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NO"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         }
       ],
       "nypl:eddRequestable": {
@@ -500,37 +560,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         }
       ],
       "nypl:eddRequestable": {
@@ -693,7 +765,7 @@
       "skos:prefLabel": "Mathematics Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
+      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -702,8 +774,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "JL",
-      "skos:prefLabel": "JL"
+      "skos:notation": "BT",
+      "skos:prefLabel": "Butler Preservation"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/JM",
@@ -765,16 +837,37 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NF"
@@ -783,19 +876,10 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
         }
       ],
       "nypl:eddRequestable": {
@@ -807,6 +891,19 @@
       },
       "skos:notation": "GN",
       "skos:prefLabel": "Government Documents"
+    },
+    {
+      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@type": "nypl:RecapCustomerCode",
+      "nypl:eddRequestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:owner": {
+        "@id": "nyplOrg:0002"
+      },
+      "skos:notation": "BS",
+      "skos:prefLabel": "Business/Econ Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/GE",
@@ -1130,7 +1227,7 @@
         "@id": "nyplOrg:0001"
       },
       "skos:notation": "ON",
-      "skos:prefLabel": "SASB Noma Scholar Room*"
+      "skos:prefLabel": "SASB Shoichi Noma Scholar Room*"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/OH",
@@ -1238,19 +1335,6 @@
       },
       "skos:notation": "HR",
       "skos:prefLabel": "HR"
-    },
-    {
-      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
-      "@type": "nypl:RecapCustomerCode",
-      "nypl:eddRequestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:owner": {
-        "@id": "nyplOrg:0003"
-      },
-      "skos:notation": "PK",
-      "skos:prefLabel": "Mendel Music Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/QK",
@@ -1626,7 +1710,7 @@
       "skos:prefLabel": "Lehman Library"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BT",
+      "@id": "http://data.nypl.org/recapCustomerCodes/JL",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
@@ -1635,8 +1719,8 @@
       "nypl:owner": {
         "@id": "nyplOrg:0002"
       },
-      "skos:notation": "BT",
-      "skos:prefLabel": "Butler Preservation"
+      "skos:notation": "JL",
+      "skos:prefLabel": "JL"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/BU",
@@ -1656,7 +1740,22 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
@@ -1665,28 +1764,25 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NB"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
         }
       ],
       "nypl:eddRequestable": {
@@ -1704,25 +1800,19 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NH"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NM"
@@ -1731,10 +1821,28 @@
           "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+          "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NF"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
         }
       ],
       "nypl:eddRequestable": {
@@ -1761,17 +1869,17 @@
       "skos:prefLabel": "BR"
     },
     {
-      "@id": "http://data.nypl.org/recapCustomerCodes/BS",
+      "@id": "http://data.nypl.org/recapCustomerCodes/PK",
       "@type": "nypl:RecapCustomerCode",
       "nypl:eddRequestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:owner": {
-        "@id": "nyplOrg:0002"
+        "@id": "nyplOrg:0003"
       },
-      "skos:notation": "BS",
-      "skos:prefLabel": "Business/Econ Library"
+      "skos:notation": "PK",
+      "skos:prefLabel": "Mendel Music Library"
     },
     {
       "@id": "http://data.nypl.org/recapCustomerCodes/JD",
@@ -1869,37 +1977,49 @@
       "@type": "nypl:RecapCustomerCode",
       "nypl:deliverableTo": [
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-        },
-        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NP"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NF"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OW"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NM"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NG"
         },
         {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
-        },
-        {
-          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+          "@id": "http://data.nypl.org/recapCustomerCodes/OA"
         },
         {
           "@id": "http://data.nypl.org/recapCustomerCodes/NR"
         },
         {
+          "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ON"
+        },
+        {
           "@id": "http://data.nypl.org/recapCustomerCodes/NJ"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NO"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NB"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/NH"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/OC"
+        },
+        {
+          "@id": "http://data.nypl.org/recapCustomerCodes/ND"
         }
       ],
       "nypl:eddRequestable": {


### PR DESCRIPTION
The discovery-api now has the ability to take a patron's ID, get its ptype  - and - by using our [by_patron_type mapping](https://github.com/NYPL/nypl-core-objects/blob/master/lib/by_patron_type_factory.js), say what types of rooms he/she has access to.

If the patron's ptype forbids it from seeing Scholar rooms - we should filter 'Scholar' rooms from `sierraDeliverLocations[]`.

This gives each object in that Array - a new property `deliveryLocationTypes`.
It will always be an Array of strings like "Research" and "Scholar".
 
 