### PR TITLE
Add deliveryLocationTypes[] to each sierra location

### DIFF
--- a/lib/by_sierra_location_factory.js
+++ b/lib/by_sierra_location_factory.js
@@ -73,7 +73,8 @@ class BySierraLocationFactory extends FactoryBase {
         label,
         collectionTypes,
         recapLocation: thisLocationAsRecap,
-        sierraDeliveryLocations
+        sierraDeliveryLocations,
+        deliveryLocationTypes: jsonldParseUtils.forcetoFlatArray(location['nypl:deliveryLocationType'])
       }
       return _returnedMap
     }, {})

--- a/test/by-sierra-location.test.js
+++ b/test/by-sierra-location.test.js
@@ -58,6 +58,7 @@ describe('by-sierra-location', function () {
     it('has collectionTypes', function () {
       Object.keys(this.bySierraLocation).forEach((sierraCode) => {
         expect(this.bySierraLocation[sierraCode].collectionTypes).to.be.a('array')
+        expect(this.bySierraLocation[sierraCode].deliveryLocationTypes).to.be.a('array')
         expect(this.bySierraLocation[sierraCode].collectionTypes).to.not.be.empty
       })
     })


### PR DESCRIPTION
This adds the same information that was added in https://github.com/NYPL/nypl-core-objects/pull/7 - but to each sierraLocation in our `by-sierra-location` map.
