### PR TITLE
Write mappings to disk and document pushing to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+output/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 output/*.json
+!/output/.gitkeep

--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ This node module live-loads the json-ld from `NYPL/nypl-core` in and turns them
 into very parsable data-structures for use in your app. **This doesn't expose all the mappings yet**,
 see the [Supported Object Types](#supported-object-types) section.
 
+### It Can Also Write Those Mappings To Disk
+
+Some non-JS apps want to use these mappings.
+By running: `./bin/write-mappings.js` - the mappings are written to `./output/`.
+
+Those files can be pushed to S3 so any application can parse them as simple JSON.
+This repo may, one day, stop exporting objects and just be a means of generating
+JSON artifacts for pushing to S3.
+
+#### Pushing to S3
+
+`aws s3 cp output s3://bucket-name/ --recursive --acl public-read --cache-control max-age=300 --profile your-aws-cli-profile-name`
+
+Note this command is `cp`, not `sync`. This uploads any new or updated files, but does not remove deleted files.
+
+Our bucket names in the **nypl-digital-dev** account are:
+
+* `nypl-core-objects-mapping-qa`
+* `nypl-core-objects-mapping-production`
+
+We'll flesh out documentation on using mappings from S3 as more apps take this on.
+
 ## Install
 
 ### From Github

--- a/bin/write-mappings.js
+++ b/bin/write-mappings.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// This executable can get more sophisticated in the future.
+// Possible improvements are:
+//   * Using reflection to not need a manual mapping_files Array
+//   * Taking an outputdirectory flag
+
 const fs = require('fs')
 const path = require('path')
 

--- a/bin/write-mappings.js
+++ b/bin/write-mappings.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+let mapping_files = [
+  'by_patron_type_factory',
+  'by_recap_customer_code_factory',
+  'by_sierra_location_factory'
+]
+
+let filesWritten = []
+
+mapping_files.forEach((mapping_file) => {
+  let mapping = require(path.join(__dirname, '..', 'lib', mapping_file)).createMapping()
+  let output_file_name = `${mapping_file.replace('_factory', '')}.json`
+
+  fs.writeFile(path.join(__dirname, '..', 'output', output_file_name), JSON.stringify(mapping), function (err) {
+    if (err) {
+      return console.log(err)
+    }
+    filesWritten.push(output_file_name)
+    console.log(`saving ${output_file_name}`)
+  })
+})


### PR DESCRIPTION
Hey @nonword 

This branch:

* adds a first pass at a script that writes (gitignored) .json files to disk.
* documents how to push those artifacts to S3.
* Also documents possible improvements.

There's a lot of bikeshedding to be done about to the script and this repo's
future as a strictly node module, and I've documented that - but this is the bare minimum to unblock our teammates by making JSON files that can be pushed to S3.

Stephen