### PR TITLE
Change location label mapping to nypl:actualLocation

### DIFF
--- a/lib/by_sierra_location_factory.js
+++ b/lib/by_sierra_location_factory.js
@@ -9,7 +9,7 @@ class BySierraLocationFactory extends FactoryBase {
 
     return this._getSierraJsonLD()['@graph'].reduce((_returnedMap, location) => {
       var code = location['skos:notation']
-      var label = location['skos:prefLabel']
+      var label = location['nypl:actualLocation']
       var locationsApiSlug = location['nypl:locationsSlug'] || null
 
       let sierraDeliveryLocations = []


### PR DESCRIPTION
To fix accessibility issues (e.g. abbreviations) this PR changes the location label mapping from `skos:prefLabel` to `nypl:actualLocation`.

@seanredmond, can you confirm that  `nypl:actualLocation` in https://github.com/NYPL/nypl-core/blob/master/vocabularies/csv/locations.csv has the correct/ideal values?