### PR TITLE
Add central handling of github 400/500 errors

### DIFF
--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -4,21 +4,21 @@ const jsonldParseUtils = require('./jsonld-parse-utils')
 class FactoryBase {
   static _getSierraJsonLD () {
     if (!this.locationsJsonLD) {
-      this.locationsJsonLD = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/locations.json').getBody())
+      this.locationsJsonLD = this._getJsonLD('locations')
     }
     return this.locationsJsonLD
   }
 
   static _getRecapJsonLD () {
     if (!this.recapCustomerCodes) {
-      this.recapCustomerCodes = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/recapCustomerCodes.json').getBody())
+      this.recapCustomerCodes = this._getJsonLD('recapCustomerCodes')
     }
     return this.recapCustomerCodes
   }
 
   static _getPatronTypeJsonLD () {
     if (!this.patronTypeJsonLD) {
-      this.patronTypeJsonLD = JSON.parse(request('GET', 'https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/patronTypes.json').getBody())
+      this.patronTypeJsonLD = this._getJsonLD('patronTypes')
     }
     return this.patronTypeJsonLD
   }
@@ -30,10 +30,23 @@ class FactoryBase {
       if (!this._jsonld_cache) this._jsonld_cache = {}
 
       var content = null
+      let statusCode = null
       try {
         content = request('GET', `https://raw.githubusercontent.com/NYPL/nypl-core/master/vocabularies/json-ld/${filename}.json`).getBody()
+
+        // Depending on the response, `sync-request` may throw an error or return a Response object
+        // If latter, grab statusCode (just in case it's >= 400)
+        statusCode = content.statusCode
       } catch (e) {
+        // If `sync-request` throws an error, grab statusCode from that error:
+        statusCode = e.statusCode
+      }
+
+      // Handle 400+, 500+ status codes
+      if (statusCode >= 400 && statusCode < 500) {
         throw new FactoryBase.MappingNameError(`Unrecognized mapping file: ${filename}`)
+      } else if (statusCode >= 500) {
+        throw new FactoryBase.MappingFileRequestError(`Upstream responded with ${statusCode} for mapping file: ${filename}`)
       }
 
       this._jsonld_cache[filename] = JSON.parse(content)
@@ -71,6 +84,13 @@ class FactoryBase {
     }, {})
   }
 }
+
+// Custom error class for reporting upstream errors (e.g. raw.githubusercontent 500)
+FactoryBase.MappingFileRequestError = function (message) {
+  this.name = 'MappingFileRequestError'
+  this.message = (message || '')
+}
+FactoryBase.MappingFileRequestError.prototype = Error.prototype
 
 // Custom error class for reporting unrecognized mapping filenames
 FactoryBase.MappingNameError = function (message) {


### PR DESCRIPTION
This PR addresses a gap in upstream error handling:

 - Adds new MappingFileRequestError custom error to report on 5xx status codes from github (as distinct from 4xx errors)
 - Centralize response parsing for locations, patronTypes, and recapCustomerCodes json documents (previously response errors were not translated to custom errors)