### PR TITLE
Add 'npm run' commands to build aritfacts and deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ see the [Supported Object Types](#supported-object-types) section.
 ### It Can Also Write Those Mappings To Disk
 
 Some non-JS apps want to use these mappings.
-By running: `./bin/write-mappings.js` - the mappings are written to `./output/`.
+By running: `npm run build-mappings`.
+The mappings are written to `./output/`.
 
 Those files can be pushed to S3 so any application can parse them as simple JSON.
 This repo may, one day, stop exporting objects and just be a means of generating
@@ -30,16 +31,10 @@ JSON artifacts for pushing to S3.
 
 #### Pushing to S3
 
-`aws s3 cp output s3://bucket-name/ --recursive --acl public-read --cache-control max-age=300 --profile your-aws-cli-profile-name`
+`npm run deploy-[qa|production]`
 
-Note this command is `cp`, not `sync`. This uploads any new or updated files, but does not remove deleted files.
-
-Our bucket names in the **nypl-digital-dev** account are:
-
-* `nypl-core-objects-mapping-qa`
-* `nypl-core-objects-mapping-production`
-
-We'll flesh out documentation on using mappings from S3 as more apps take this on.
+This command is `cp`, not `sync`.
+It uploads any new or updated files, but does not remove deleted files.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "standard": "6.0.8"
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard --env mocha --globals expect && ./node_modules/.bin/mocha test"
+    "test": "./node_modules/.bin/standard --env mocha --globals expect && ./node_modules/.bin/mocha test",
+    "build-mappings": "rm -rf ./output/*.json && node ./bin/write-mappings",
+    "deploy-qa": "npm run build-mappings && aws s3 cp output s3://nypl-core-objects-mapping-qa/ --recursive --acl public-read --cache-control max-age=300 --profile nypl-digital-dev",
+    "deploy-production": "npm run build-mappings && aws s3 cp output s3://nypl-core-objects-mapping-production/ --recursive --acl public-read --cache-control max-age=300 --profile nypl-digital-dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This also cleans up the README to reference the 'npm run' commands.
I also cut down documentation in the README that folks can divine
by reading the 'npm run' commands in package.json.