### PR TITLE
Add catalogItemType mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ For a comprehensive list of availability see the implementation of factories men
 * Locations (from [locations.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/locations.json) & [recapCustomerCodes.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/recapCustomerCodes.json))
 
 * Patron Types (from [patronTypes.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/patronTypes.json))
-## Git Workflow
 
+* Catalog Item Types (from [catalogItemType.json](https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/catalogItemTypes.json))
+
+## Git Workflow
 When you _file_ a PR - it should include a version bump.  
 When you _accept_ a PR - you should push a tag named "vTHEVERSION" (e.g. "v1.0.1")

--- a/bin/write-mappings.js
+++ b/bin/write-mappings.js
@@ -13,7 +13,8 @@ let mapping_names = [
   'by_patron_type',
   'by_recap_customer_code',
   'by_sierra_location',
-  'by_statuses'
+  'by_statuses',
+  'by_catalog_item_type'
 ]
 
 let filesWritten = []

--- a/lib/by_catalog_item_type_factory.js
+++ b/lib/by_catalog_item_type_factory.js
@@ -1,0 +1,21 @@
+const jsonldParseUtils = require('./jsonld-parse-utils')
+const FactoryBase = require('./factory_base')
+
+class ByCatalogItemTypeFactory extends FactoryBase {
+
+  /**
+   * Returns a mapping for Catalog Item Types
+   */
+  static createMapping () {
+    return super.createMapping('by-catalog-item-types', {
+      propertyMapper: {
+        locationType: (item) => {
+          let locationTypes = item['nypl:locationType'] ? jsonldParseUtils.forcetoFlatArray(item['nypl:locationType']) : []
+          return locationTypes
+        }
+      }
+    })
+  }
+}
+
+module.exports = ByCatalogItemTypeFactory

--- a/lib/factory_base.js
+++ b/lib/factory_base.js
@@ -41,8 +41,32 @@ class FactoryBase {
     }
   }
 
-  // returns a base-line hash mapping code/id to a minimum field set (just labels for now)
-  static createMapping (key) {
+  /**
+   * Returns a baseline hash that maps code/id to a minimum field set (just labels, requestable for now)
+   *
+   * @param {string} key Specifies the mapping to generate (e.g. by-catalog-item-types)
+   * @param {hash} options Optional hash of options, which may include the following:
+   *  * propertyMapper: Hash mapping property names to a formatting function that takes the entity as sole argument
+   *
+   * The options.propertyMapper allows you to leverage a baseline mapping
+   * but also layer in additional properties extracted however you like.
+   *
+   * For example, the following generates a baseline mapping for catalog item types
+   * with an additional 'locationType' property extracted from nypl:locationType:
+   *
+   *   FactoryBase.createMapping('by-catalog-item-types', {
+   *     propertyMapper: {
+   *       locationType: (item) => {
+   *         return item['nypl:locationType'] ? jsonldParseUtils.forcetoFlatArray(item['nypl:locationType']) : []
+   *       }
+   *     }
+   *   })
+   */
+  static createMapping (key, options = {}) {
+    options = Object.assign({
+      propertyMapper: null
+    }, options)
+
     // Convert from hyphen "by-..." phrase to the known github file naming convention for mapping files
     // e.g. from 'by-catalog-item-types' to 'catalogItemTypes'
     let filename = jsonldParseUtils.hyphenToCamelCase(key.replace(/^by-/, ''))
@@ -65,6 +89,13 @@ class FactoryBase {
       if (item['skos:notation']) mappedFields.code = item['skos:notation']
       if (item['skos:prefLabel']) mappedFields.label = item['skos:prefLabel']
       if (item['nypl:requestable']) mappedFields.requestable = jsonldParseUtils._conditional_boolean(item['nypl:requestable'])
+
+      // Extract custom properties based on propertyMapper hash of functions:
+      if (options.propertyMapper) {
+        Object.keys(options.propertyMapper).forEach((property) => {
+          mappedFields[property] = options.propertyMapper[property](item)
+        })
+      }
 
       result[mappingKey] = mappedFields
       return result

--- a/nypl-core-objects.js
+++ b/nypl-core-objects.js
@@ -1,6 +1,7 @@
 const ByRecapCustomerCodeFactory = require('./lib/by_recap_customer_code_factory')
 const BySierraLocationFactory = require('./lib/by_sierra_location_factory')
 const ByPatronTypeFactory = require('./lib/by_patron_type_factory')
+const ByCatalogItemTypeFactory = require('./lib/by_catalog_item_type_factory')
 const FactoryBase = require('./lib/factory_base')
 
 module.exports = (maptype) => {
@@ -14,6 +15,8 @@ module.exports = (maptype) => {
       return BySierraLocationFactory.createMapping()
     case 'by-patron-type':
       return ByPatronTypeFactory.createMapping()
+    case 'by-catalog-item-type':
+      return ByCatalogItemTypeFactory.createMapping()
     default:
       // Attempt to create a basic map based on maptype:
       // Will throw a MappingNameError if unrecognized

--- a/test/by-catalog-item-type.test.js
+++ b/test/by-catalog-item-type.test.js
@@ -1,0 +1,43 @@
+let expect = require('chai').expect
+const sinon = require('sinon')
+const fs = require('fs')
+const path = require('path')
+
+let FactoryBase = require('../lib/factory_base')
+
+function takeThisPartyOffline () {
+  // Overwrite FactoryBase._getJsonLD with a stub that returns local json:
+  let mockedCatalogItemTypeJSONLD = function () {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, './resources/catalogItemTypes.json')))
+  }
+  sinon.stub(FactoryBase, '_getJsonLD').callsFake(mockedCatalogItemTypeJSONLD)
+}
+
+function revertTakingOfPartyOffline () {
+  // Restore FactoryBase._getJsonLD to original for other tests:
+  FactoryBase._getJsonLD.restore()
+}
+
+describe('by-catalog-item-type', function () {
+  before(function () {
+    takeThisPartyOffline()
+    this.byCatalogItemType = require('../nypl-core-objects')('by-catalog-item-type')
+  })
+
+  after(revertTakingOfPartyOffline)
+
+  it('exports a simpleObject', function (done) {
+    expect(this.byCatalogItemType).to.not.equal(undefined)
+    expect(this.byCatalogItemType).to.be.a('object')
+    done()
+  })
+
+  it('will have "label" & "locationType" properties for each key', function () {
+    expect(Object.keys(this.byCatalogItemType)).to.not.be.empty
+    for (let key in this.byCatalogItemType) {
+      let catalogItemType = this.byCatalogItemType[key]
+      expect(catalogItemType['label']).to.be.a('string')
+      expect(catalogItemType['locationType']).to.not.be.empty
+    }
+  })
+})


### PR DESCRIPTION
This PR adds a by-catalog-item-type mapping to the library. In so doing, it also proposes a way we can leverage the generic `FactoryBase.createMapping` while also layering additional properties over that baseline mapping. The Catalog Item Type vocab is a good test case because most of what we need mapped is already handled by `FactoryBase.createMapping`. The proposal is that we allow the caller to specify an optional `propertyMapper` function that specifies any number of additional extractions to make.

I think there may be a more elegant way to leverage inheritance here so that FactoryBase and ByCatalogItemTypeFactory behave more like nested serializers, but the proposed approach feels clear enough for now.