### PR TITLE
Fix by-sierra-location to use collectionType

### DIFF
--- a/lib/by_sierra_location_factory.js
+++ b/lib/by_sierra_location_factory.js
@@ -58,9 +58,8 @@ class BySierraLocationFactory extends FactoryBase {
 
       recapCodesforSierraDeliverableLocations = jsonldParseUtils.forcetoFlatArray(recapCodesforSierraDeliverableLocations)
 
-      // Note: This is about to change to .. collectionType?
-      // It it isn't set, default to 'Branch'
-      let collectionTypes = jsonldParseUtils.forcetoFlatArray(location['nypl:locationType'] || 'Branch')
+      // If collectionType isn't set (it should be for all), default to 'Branch'
+      let collectionTypes = jsonldParseUtils.forcetoFlatArray(location['nypl:collectionType'] || 'Branch')
 
       _returnedMap[code] = {
         code,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "standard": "6.0.8"
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard --env mocha --globals expect && ./node_modules/.bin/mocha test",
+    "test": "./node_modules/.bin/standard --env mocha && ./node_modules/.bin/mocha test",
     "build-mappings": "rm -rf ./output/*.json && node ./bin/write-mappings",
     "deploy-qa": "npm run build-mappings && aws s3 cp output s3://nypl-core-objects-mapping-qa/ --recursive --acl public-read --cache-control max-age=300 --profile nypl-digital-dev",
     "deploy-production": "npm run build-mappings && aws s3 cp output s3://nypl-core-objects-mapping-production/ --recursive --acl public-read --cache-control max-age=300 --profile nypl-digital-dev"

--- a/test/by-sierra-location.test.js
+++ b/test/by-sierra-location.test.js
@@ -70,4 +70,18 @@ describe('by-sierra-location', function () {
       })
     })
   })
+
+  describe('location collectionType', function () {
+    it('nyplLocation:ft (53rd St) has collectionType "Branch"', function () {
+      expect(this.bySierraLocation['ft'].collectionTypes).to.be.a('array')
+      expect(this.bySierraLocation['ft'].collectionTypes).to.have.lengthOf(1)
+      expect(this.bySierraLocation['ft'].collectionTypes).to.have.members(['Branch'])
+    })
+
+    it('nyplLocation:ia (Electronic Material for Adults) has collectionType "Branch", "Research"', function () {
+      expect(this.bySierraLocation['ia'].collectionTypes).to.be.a('array')
+      expect(this.bySierraLocation['ia'].collectionTypes).to.have.lengthOf(2)
+      expect(this.bySierraLocation['ia'].collectionTypes).to.have.members(['Research', 'Branch'])
+    })
+  })
 })

--- a/test/resources/locations.json
+++ b/test/resources/locations.json
@@ -20,6 +20,27 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:myr"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
           "@id": "nyplLocation:slr"
         },
         {
@@ -29,34 +50,13 @@
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mai"
-        },
-        {
           "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:malc"
         }
       ],
       "nypl:owner": {
@@ -147,67 +147,23 @@
       "skos:prefLabel": "Castle Hill Children's Young Reader"
     },
     {
-      "@id": "nyplLocation:qc2ma",
+      "@id": "nyplLocation:mnj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:qc"
+        "@id": "nyplLocation:mn"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:myr"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        }
-      ],
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/0001"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "OFFSITE - TSD - Request in Advance",
-      "skos:notation": "qc2ma",
-      "skos:prefLabel": "Temporary Storage"
+      "skos:altLabel": "Mariner's Harbor Children's Reference",
+      "skos:notation": "mnj01",
+      "skos:prefLabel": "Mariner's Harbor Children's Reference"
     },
     {
       "@id": "nyplLocation:ctj0a",
@@ -324,10 +280,10 @@
       "skos:prefLabel": "Castle Hill Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:ctj0n",
+      "@id": "nyplLocation:tgzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ct"
+        "@id": "nyplLocation:tg"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -338,9 +294,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Castle Hill Children's Non-Fiction",
-      "skos:notation": "ctj0n",
-      "skos:prefLabel": "Castle Hill Children's Non-Fiction"
+      "skos:altLabel": "Throg's Neck (error code)",
+      "skos:notation": "tgzzz",
+      "skos:prefLabel": "Throg's Neck"
     },
     {
       "@id": "nyplLocation:ctj0l",
@@ -508,9 +464,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "maii2",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 119"
     },
     {
       "@id": "nyplLocation:maii3",
@@ -533,9 +489,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "maii3",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Reference Desk Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Reference Desk Room 119"
     },
     {
       "@id": "nyplLocation:maii1",
@@ -558,9 +514,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "maii1",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Reference Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Reference Room 119"
     },
     {
       "@id": "nyplLocation:sby0v",
@@ -696,10 +652,10 @@
       "skos:prefLabel": "Mariner's Harbor Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:mnj0t",
+      "@id": "nyplLocation:hsyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mn"
+        "@id": "nyplLocation:hs"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -710,28 +666,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mariner's Harbor Children's Fairy Tale",
-      "skos:notation": "mnj0t",
-      "skos:prefLabel": "Mariner's Harbor Children's Fairy Tale"
-    },
-    {
-      "@id": "nyplLocation:kpa03",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:kp"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Kips Bay Closed Shelf Reference",
-      "skos:notation": "kpa03",
-      "skos:prefLabel": "Kips Bay Closed Shelf Reference"
+      "skos:altLabel": "Hunt's Point Young Adult Reference",
+      "skos:notation": "hsyr",
+      "skos:prefLabel": "Hunt's Point Young Adult Reference"
     },
     {
       "@id": "nyplLocation:mnj0n",
@@ -772,23 +709,67 @@
       "skos:prefLabel": "Mariner's Harbor Children's World Languages"
     },
     {
-      "@id": "nyplLocation:mnj01",
+      "@id": "nyplLocation:qc2ma",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mn"
+        "@id": "nyplLocation:qc"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": [
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:slr"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:sc"
+        },
+        {
+          "@id": "nyplLocation:myr"
+        }
+      ],
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/0001"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mariner's Harbor Children's Reference",
-      "skos:notation": "mnj01",
-      "skos:prefLabel": "Mariner's Harbor Children's Reference"
+      "skos:altLabel": "OFFSITE - TSD - Request in Advance",
+      "skos:notation": "qc2ma",
+      "skos:prefLabel": "Temporary Storage"
     },
     {
       "@id": "nyplLocation:mnj0i",
@@ -848,10 +829,10 @@
       "skos:prefLabel": "Mariner's Harbor Children's Fiction"
     },
     {
-      "@id": "nyplLocation:brj",
+      "@id": "nyplLocation:hly01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:br"
+        "@id": "nyplLocation:hl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -862,9 +843,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "George Bruce Children",
-      "skos:notation": "brj",
-      "skos:prefLabel": "George Bruce Children"
+      "skos:altLabel": "Harlem YA Reference",
+      "skos:notation": "hly01",
+      "skos:prefLabel": "Harlem YA Reference"
     },
     {
       "@id": "nyplLocation:mnj0a",
@@ -955,16 +936,22 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:maln"
@@ -973,16 +960,10 @@
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mab"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:mai"
         }
       ],
       "nypl:owner": {
@@ -994,7 +975,7 @@
       },
       "skos:altLabel": "SASB M2 - Dorot Jewish Division - Room 111",
       "skos:notation": "maf92",
-      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division - Room 111"
+      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division Room 111"
     },
     {
       "@id": "nyplLocation:gczzz",
@@ -1052,6 +1033,44 @@
       "skos:altLabel": "Yorkville YA Fiction",
       "skos:notation": "yvy0f",
       "skos:prefLabel": "Yorkville YA Fiction"
+    },
+    {
+      "@id": "nyplLocation:fea01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:fe"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "58th Street Reference",
+      "skos:notation": "fea01",
+      "skos:prefLabel": "58th Street Reference"
+    },
+    {
+      "@id": "nyplLocation:stj",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:st"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Stapleton Children",
+      "skos:notation": "stj",
+      "skos:prefLabel": "Stapleton Children"
     },
     {
       "@id": "nyplLocation:lmzzz",
@@ -1475,10 +1494,10 @@
       "skos:prefLabel": "St. Agnes YA Reference"
     },
     {
-      "@id": "nyplLocation:tgzzz",
+      "@id": "nyplLocation:ctj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
+        "@id": "nyplLocation:ct"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -1489,9 +1508,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Throg's Neck (error code)",
-      "skos:notation": "tgzzz",
-      "skos:prefLabel": "Throg's Neck"
+      "skos:altLabel": "Castle Hill Children's Non-Fiction",
+      "skos:notation": "ctj0n",
+      "skos:prefLabel": "Castle Hill Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:feyr",
@@ -1522,6 +1541,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -1543,6 +1563,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -1564,6 +1585,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -1593,6 +1615,28 @@
       "skos:altLabel": "Kips Bay Children's Reference",
       "skos:notation": "kpj01",
       "skos:prefLabel": "Kips Bay Children's Reference"
+    },
+    {
+      "@id": "nyplLocation:mm2yf",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2yf",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:pry",
@@ -2016,7 +2060,7 @@
       },
       "skos:altLabel": "SASB M2 - Dorot Jewish Division - Room 111",
       "skos:notation": "maf98",
-      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division - Room 111"
+      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division Room 111"
     },
     {
       "@id": "nyplLocation:mym11",
@@ -2044,10 +2088,10 @@
       "skos:prefLabel": "Performing Arts Research Collections - Music - Reference"
     },
     {
-      "@id": "nyplLocation:ndy01",
+      "@id": "nyplLocation:fey0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nd"
+        "@id": "nyplLocation:fe"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -2058,9 +2102,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "New Dorp YA Reference",
-      "skos:notation": "ndy01",
-      "skos:prefLabel": "New Dorp YA Reference"
+      "skos:altLabel": "58th Street YA Non-Fiction",
+      "skos:notation": "fey0n",
+      "skos:prefLabel": "58th Street YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:xfill",
@@ -2823,6 +2867,25 @@
       "skos:prefLabel": "Mosholu Adult Reference"
     },
     {
+      "@id": "nyplLocation:mnj0t",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mn"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mariner's Harbor Children's Fairy Tale",
+      "skos:notation": "mnj0t",
+      "skos:prefLabel": "Mariner's Harbor Children's Fairy Tale"
+    },
+    {
       "@id": "nyplLocation:yvj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -2956,6 +3019,25 @@
       "skos:prefLabel": "Yorkville Children's Fiction"
     },
     {
+      "@id": "nyplLocation:eajr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ea"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Eastchester Children's Reference",
+      "skos:notation": "eajr",
+      "skos:prefLabel": "Eastchester Children's Reference"
+    },
+    {
       "@id": "nyplLocation:yvj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -2992,25 +3074,6 @@
       "skos:altLabel": "Yorkville Children's Holiday Book",
       "skos:notation": "yvj0h",
       "skos:prefLabel": "Yorkville Children's Holiday Book"
-    },
-    {
-      "@id": "nyplLocation:cpj0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Clason's Point Children's World Languages",
-      "skos:notation": "cpj0l",
-      "skos:prefLabel": "Clason's Point Children's World Languages"
     },
     {
       "@id": "nyplLocation:mbar",
@@ -3184,23 +3247,24 @@
       "skos:prefLabel": "Van Nest Adult Reference"
     },
     {
-      "@id": "nyplLocation:why0l",
+      "@id": "nyplLocation:x001",
       "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
-      },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/IN"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Washington Heights YA World Languages",
-      "skos:notation": "why0l",
-      "skos:prefLabel": "Washington Heights YA World Languages"
+      "skos:altLabel": "ReCAP Inter-Library Loan",
+      "skos:notation": "x001",
+      "skos:prefLabel": "ReCAP Inter-Library Loan"
     },
     {
       "@id": "nyplLocation:chy",
@@ -3298,24 +3362,23 @@
       "skos:prefLabel": "Roosevelt Island"
     },
     {
-      "@id": "nyplLocation:x003",
+      "@id": "nyplLocation:why0n",
       "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wh"
+      },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "false"
+        "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:deliveryLocationType": "Research",
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/RR"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "ReCAP Reading Room",
-      "skos:notation": "x003",
-      "skos:prefLabel": "ReCAP Reading Room"
+      "skos:altLabel": "Washington Heights YA Non-Fiction",
+      "skos:notation": "why0n",
+      "skos:prefLabel": "Washington Heights YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:epa",
@@ -3375,26 +3438,23 @@
       "skos:prefLabel": "West Farms YA World Languages"
     },
     {
-      "@id": "nyplLocation:rc",
+      "@id": "nyplLocation:gdy",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rc"
+        "@id": "nyplLocation:gd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/0001"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
-      "skos:altLabel": "NYPL Research Libraries",
-      "skos:notation": "rc",
-      "skos:prefLabel": "Offsite"
+      "skos:altLabel": "Grand Concourse Young Adult",
+      "skos:notation": "gdy",
+      "skos:prefLabel": "Grand Concourse Young Adult"
     },
     {
       "@id": "nyplLocation:epy",
@@ -3606,6 +3666,32 @@
       "skos:prefLabel": "Bronx Library Center Fiction"
     },
     {
+      "@id": "nyplLocation:x009",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:sc"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1001"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/OM"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Schomburg Gen. no Sierra holds",
+      "skos:notation": "x009",
+      "skos:prefLabel": "Schomburg Gen. no Sierra holds"
+    },
+    {
       "@id": "nyplLocation:cty",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -3661,6 +3747,25 @@
       "skos:altLabel": "Bronx Library Center Non-Fiction",
       "skos:notation": "bca0n",
       "skos:prefLabel": "Bronx Library Center Non-Fiction"
+    },
+    {
+      "@id": "nyplLocation:alj0y",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:al"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Allerton Children's Young Reader",
+      "skos:notation": "alj0y",
+      "skos:prefLabel": "Allerton Children's Young Reader"
     },
     {
       "@id": "nyplLocation:cta",
@@ -3751,22 +3856,25 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:malc"
         },
         {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:mai"
@@ -3775,10 +3883,7 @@
           "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:maln"
         }
       ],
       "nypl:owner": {
@@ -3802,6 +3907,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -4105,7 +4211,7 @@
       },
       "skos:altLabel": "SASB M2 - Manuscripts Division - Room 328",
       "skos:notation": "mao92",
-      "skos:prefLabel": "Schwarzman Building M2 - Manuscripts Division - Room 328"
+      "skos:prefLabel": "Schwarzman Building M2 - Manuscripts Division Room 328"
     },
     {
       "@id": "nyplLocation:bca01",
@@ -4298,23 +4404,34 @@
       "skos:prefLabel": "Macomb's Bridge Children's Reference"
     },
     {
-      "@id": "nyplLocation:ciyr",
+      "@id": "nyplLocation:sce",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ci"
+        "@id": "nyplLocation:sc"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:sc"
+      },
+      "nypl:deliveryLocationType": "Research",
+      "nypl:locationsSlug": "photographs-and-prints-division",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1118"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SP"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "City Island Young Adult Reference",
-      "skos:notation": "ciyr",
-      "skos:prefLabel": "City Island Young Adult Reference"
+      "skos:altLabel": "Schomburg Center - Photographs & Prints",
+      "skos:notation": "sce",
+      "skos:prefLabel": "Schomburg Center - Photographs & Prints"
     },
     {
       "@id": "nyplLocation:vcj",
@@ -4345,6 +4462,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -4553,6 +4671,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -4655,6 +4774,25 @@
       "skos:altLabel": "Tottenville Young Adult Reference",
       "skos:notation": "tvyr",
       "skos:prefLabel": "Tottenville Young Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:bry01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:br"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "George Bruce YA Reference",
+      "skos:notation": "bry01",
+      "skos:prefLabel": "George Bruce YA Reference"
     },
     {
       "@id": "nyplLocation:mbj0y",
@@ -4771,10 +4909,10 @@
       "skos:prefLabel": "Macomb's Bridge Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:wly01",
+      "@id": "nyplLocation:mbj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
+        "@id": "nyplLocation:mb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -4785,9 +4923,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Woodlawn Heights YA Reference",
-      "skos:notation": "wly01",
-      "skos:prefLabel": "Woodlawn Heights YA Reference"
+      "skos:altLabel": "Macomb's Bridge Children's Fairy Tale",
+      "skos:notation": "mbj0t",
+      "skos:prefLabel": "Macomb's Bridge Children's Fairy Tale"
     },
     {
       "@id": "nyplLocation:mpa0f",
@@ -4927,25 +5065,6 @@
       "skos:altLabel": "OFFSITE - Request in Advance",
       "skos:notation": "rc2mj",
       "skos:prefLabel": "Offsite"
-    },
-    {
-      "@id": "nyplLocation:bay01",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ba"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Baychester YA Reference",
-      "skos:notation": "bay01",
-      "skos:prefLabel": "Baychester YA Reference"
     },
     {
       "@id": "nyplLocation:gdjr",
@@ -5612,10 +5731,10 @@
       "skos:prefLabel": "Tompkins Square Non-Print Media"
     },
     {
-      "@id": "nyplLocation:nsj",
+      "@id": "nyplLocation:tsa0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ns"
+        "@id": "nyplLocation:ts"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -5626,9 +5745,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "96th Street Children",
-      "skos:notation": "nsj",
-      "skos:prefLabel": "96th Street Children"
+      "skos:altLabel": "Tompkins Square Center for Reading & Writing",
+      "skos:notation": "tsa0w",
+      "skos:prefLabel": "Tompkins Square Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:ewy01",
@@ -5707,25 +5826,23 @@
       "skos:prefLabel": "67th Street Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:sla0n",
+      "@id": "nyplLocation:mry0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sl"
+        "@id": "nyplLocation:mr"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1125"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SIBL - Non-Fiction",
-      "skos:notation": "sla0n",
-      "skos:prefLabel": "Science, Industry and Business Library (SIBL) - Non-Fiction"
+      "skos:altLabel": "Morrisania YA Non-Print Media",
+      "skos:notation": "mry0v",
+      "skos:prefLabel": "Morrisania YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:ssj0l",
@@ -5766,26 +5883,7 @@
       "skos:prefLabel": "Mott Haven Children's World Languages"
     },
     {
-      "@id": "nyplLocation:rty0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Richmondtown YA Non-Print Media",
-      "skos:notation": "rty0v",
-      "skos:prefLabel": "Richmondtown YA Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:ssj0f",
+      "@id": "nyplLocation:ssj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:ss"
@@ -5799,9 +5897,28 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "67th Street Children's Fiction",
-      "skos:notation": "ssj0f",
-      "skos:prefLabel": "67th Street Children's Fiction"
+      "skos:altLabel": "67th Street Children's Easy Book",
+      "skos:notation": "ssj0a",
+      "skos:prefLabel": "67th Street Children's Easy Book"
+    },
+    {
+      "@id": "nyplLocation:cayr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ca"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference",
+      "skos:notation": "cayr",
+      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference"
     },
     {
       "@id": "nyplLocation:dha03",
@@ -6167,6 +6284,25 @@
       "skos:prefLabel": "Tottenville Adult Reference"
     },
     {
+      "@id": "nyplLocation:tgar",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:tg"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Throg's Neck Adult Reference",
+      "skos:notation": "tgar",
+      "skos:prefLabel": "Throg's Neck Adult Reference"
+    },
+    {
       "@id": "nyplLocation:riy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -6379,10 +6515,10 @@
       "skos:prefLabel": "Huguenot Park Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:muj0v",
+      "@id": "nyplLocation:hkj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:hk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -6393,9 +6529,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Muhlenberg Children's Non-Print Media",
-      "skos:notation": "muj0v",
-      "skos:prefLabel": "Muhlenberg Children's Non-Print Media"
+      "skos:altLabel": "Huguenot Park Children's Picture Book",
+      "skos:notation": "hkj0i",
+      "skos:prefLabel": "Huguenot Park Children's Picture Book"
     },
     {
       "@id": "nyplLocation:hkj0h",
@@ -6587,6 +6723,10 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": [
+        "Branch",
+        "Research"
+      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/0001"
       },
@@ -6697,7 +6837,7 @@
       },
       "skos:altLabel": "SASB M1 - Map Division - Rm 117",
       "skos:notation": "map82",
-      "skos:prefLabel": "Schwarzman Building - Map Division - Room 117"
+      "skos:prefLabel": "Schwarzman Building - Map Division Room 117"
     },
     {
       "@id": "nyplLocation:cpj0i",
@@ -6877,10 +7017,10 @@
       "skos:prefLabel": "Morrisania YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:cpj0y",
+      "@id": "nyplLocation:rdj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:rd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -6891,15 +7031,15 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Clason's Point Children's Young Reader",
-      "skos:notation": "cpj0y",
-      "skos:prefLabel": "Clason's Point Children's Young Reader"
+      "skos:altLabel": "Riverdale Children's World Languages",
+      "skos:notation": "rdj0l",
+      "skos:prefLabel": "Riverdale Children's World Languages"
     },
     {
-      "@id": "nyplLocation:nba0v",
+      "@id": "nyplLocation:otj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
+        "@id": "nyplLocation:ot"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -6910,9 +7050,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West New Brighton Non-Print Media",
-      "skos:notation": "nba0v",
-      "skos:prefLabel": "West New Brighton Non-Print Media"
+      "skos:altLabel": "Ottendorfer Children's Non-Print Media",
+      "skos:notation": "otj0v",
+      "skos:prefLabel": "Ottendorfer Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:cpj0v",
@@ -7117,10 +7257,10 @@
       "skos:prefLabel": "Inwood Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:pky0n",
+      "@id": "nyplLocation:rtj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:rt"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -7131,9 +7271,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Parkchester YA Non-Fiction",
-      "skos:notation": "pky0n",
-      "skos:prefLabel": "Parkchester YA Non-Fiction"
+      "skos:altLabel": "Richmondtown Children's Non-Fiction",
+      "skos:notation": "rtj0n",
+      "skos:prefLabel": "Richmondtown Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:rtj0l",
@@ -7269,10 +7409,10 @@
       "skos:prefLabel": "Chatham Square World Languages"
     },
     {
-      "@id": "nyplLocation:nba0l",
+      "@id": "nyplLocation:otj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
+        "@id": "nyplLocation:ot"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -7283,9 +7423,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West New Brighton World Languages",
-      "skos:notation": "nba0l",
-      "skos:prefLabel": "West New Brighton World Languages"
+      "skos:altLabel": "Ottendorfer Children's World Languages",
+      "skos:notation": "otj0l",
+      "skos:prefLabel": "Ottendorfer Children's World Languages"
     },
     {
       "@id": "nyplLocation:jpa01",
@@ -7446,10 +7586,10 @@
       "skos:prefLabel": "Richmondtown Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:ndj0l",
+      "@id": "nyplLocation:alj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nd"
+        "@id": "nyplLocation:al"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -7460,9 +7600,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "New Dorp Children's World Languages",
-      "skos:notation": "ndj0l",
-      "skos:prefLabel": "New Dorp Children's World Languages"
+      "skos:altLabel": "Allerton Children's Non-Print Media",
+      "skos:notation": "alj0v",
+      "skos:prefLabel": "Allerton Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:hby0n",
@@ -7561,25 +7701,6 @@
       "skos:altLabel": "George Bruce YA Non-Print Media",
       "skos:notation": "bry0v",
       "skos:prefLabel": "George Bruce YA Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:rtj",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Richmondtown Children",
-      "skos:notation": "rtj",
-      "skos:prefLabel": "Richmondtown Children"
     },
     {
       "@id": "nyplLocation:mba0l",
@@ -7879,34 +8000,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
           "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:maln"
         },
         {
           "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:malc"
         }
       ],
       "nypl:owner": {
@@ -8147,25 +8268,6 @@
       "skos:altLabel": "Hamilton Grange Children's Holiday Book",
       "skos:notation": "hgj0h",
       "skos:prefLabel": "Hamilton Grange Children's Holiday Book"
-    },
-    {
-      "@id": "nyplLocation:mhj0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mh"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Mott Haven Children's Non-Fiction",
-      "skos:notation": "mhj0n",
-      "skos:prefLabel": "Mott Haven Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:malc",
@@ -8596,23 +8698,34 @@
       "skos:prefLabel": "South Beach"
     },
     {
-      "@id": "nyplLocation:stj",
+      "@id": "nyplLocation:sc",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:st"
+        "@id": "nyplLocation:sc"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:sc"
+      },
+      "nypl:deliveryLocationType": "Research",
+      "nypl:locationsSlug": "schomburg",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1001"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Stapleton Children",
-      "skos:notation": "stj",
-      "skos:prefLabel": "Stapleton Children"
+      "skos:altLabel": "Schomburg Center",
+      "skos:notation": "sc",
+      "skos:prefLabel": "Schomburg Center - Research and Reference Division"
     },
     {
       "@id": "nyplLocation:sa",
@@ -9419,6 +9532,25 @@
       "skos:prefLabel": "Morrisania Children's Fiction"
     },
     {
+      "@id": "nyplLocation:nbj0l",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:nb"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "West New Brighton Children's World Languages",
+      "skos:notation": "nbj0l",
+      "skos:prefLabel": "West New Brighton Children's World Languages"
+    },
+    {
       "@id": "nyplLocation:hfj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -9647,6 +9779,25 @@
       "skos:prefLabel": "Ottendorfer Children"
     },
     {
+      "@id": "nyplLocation:wla03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wl"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Woodlawn Heights Closed Shelf Reference",
+      "skos:notation": "wla03",
+      "skos:prefLabel": "Woodlawn Heights Closed Shelf Reference"
+    },
+    {
       "@id": "nyplLocation:ota",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -9799,6 +9950,25 @@
       "skos:prefLabel": "Todt Hill-Westerleigh Children's Fairy Tale"
     },
     {
+      "@id": "nyplLocation:tmj01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:tm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Tremont Children's Reference",
+      "skos:notation": "tmj01",
+      "skos:prefLabel": "Tremont Children's Reference"
+    },
+    {
       "@id": "nyplLocation:thj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -9894,10 +10064,10 @@
       "skos:prefLabel": "Andrew Heiskell Non-Print Media"
     },
     {
-      "@id": "nyplLocation:otj01",
+      "@id": "nyplLocation:nba01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:nb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -9908,9 +10078,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Ottendorfer Children's Reference",
-      "skos:notation": "otj01",
-      "skos:prefLabel": "Ottendorfer Children's Reference"
+      "skos:altLabel": "West New Brighton Reference",
+      "skos:notation": "nba01",
+      "skos:prefLabel": "West New Brighton Reference"
     },
     {
       "@id": "nyplLocation:thj0f",
@@ -10829,34 +10999,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:maln"
         }
       ],
       "nypl:owner": {
@@ -11271,6 +11441,28 @@
       "skos:altLabel": "Stapleton Adult Reference",
       "skos:notation": "star",
       "skos:prefLabel": "Stapleton Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:rcml8",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:rc"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "OFFSITE - Request in Advance at SASB - Rose Main Reading Room",
+      "skos:notation": "rcml8",
+      "skos:prefLabel": "Offsite"
     },
     {
       "@id": "nyplLocation:mej0h",
@@ -11710,10 +11902,10 @@
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Reference"
     },
     {
-      "@id": "nyplLocation:tvy0n",
+      "@id": "nyplLocation:tmj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tv"
+        "@id": "nyplLocation:tm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -11724,9 +11916,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Tottenville YA Non-Fiction",
-      "skos:notation": "tvy0n",
-      "skos:prefLabel": "Tottenville YA Non-Fiction"
+      "skos:altLabel": "Tremont Children's Holiday Book",
+      "skos:notation": "tmj0h",
+      "skos:prefLabel": "Tremont Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:woy0l",
@@ -11767,58 +11959,23 @@
       "skos:prefLabel": "Woodstock YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:maf82",
+      "@id": "nyplLocation:bla01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
+        "@id": "nyplLocation:bl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": [
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        }
-      ],
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1103"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB M1 - Dorot Jewish Division Rm 111",
-      "skos:notation": "maf82",
-      "skos:prefLabel": "Schwarzman Building - Dorot Jewish Division Room 111"
+      "skos:altLabel": "Bloomingdale Reference",
+      "skos:notation": "bla01",
+      "skos:prefLabel": "Bloomingdale Reference"
     },
     {
       "@id": "nyplLocation:bla03",
@@ -11928,10 +12085,10 @@
       "skos:prefLabel": "Offsite"
     },
     {
-      "@id": "nyplLocation:alj0v",
+      "@id": "nyplLocation:pkar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:al"
+        "@id": "nyplLocation:pk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -11942,9 +12099,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Allerton Children's Non-Print Media",
-      "skos:notation": "alj0v",
-      "skos:prefLabel": "Allerton Children's Non-Print Media"
+      "skos:altLabel": "Parkchester Adult Reference",
+      "skos:notation": "pkar",
+      "skos:prefLabel": "Parkchester Adult Reference"
     },
     {
       "@id": "nyplLocation:alj0i",
@@ -12384,6 +12541,25 @@
       "skos:prefLabel": "Morris Park YA Fiction"
     },
     {
+      "@id": "nyplLocation:caj0h",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ca"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Children's Holiday Book",
+      "skos:notation": "caj0h",
+      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Holiday Book"
+    },
+    {
       "@id": "nyplLocation:tmy",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -12816,6 +12992,25 @@
       "skos:prefLabel": "St. George YA Non-Print Media"
     },
     {
+      "@id": "nyplLocation:nba0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:nb"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "West New Brighton Non-Print Media",
+      "skos:notation": "nba0v",
+      "skos:prefLabel": "West New Brighton Non-Print Media"
+    },
+    {
       "@id": "nyplLocation:moj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -13025,23 +13220,26 @@
       "skos:prefLabel": "Pelham Bay Fiction"
     },
     {
-      "@id": "nyplLocation:sgj0a",
+      "@id": "nyplLocation:mm4y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "St. George Children's Easy Book",
-      "skos:notation": "sgj0a",
-      "skos:prefLabel": "St. George Children's Easy Book"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4y",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:pma0l",
@@ -13099,6 +13297,28 @@
       "skos:altLabel": "Morningside Heights YA Reference",
       "skos:notation": "cly01",
       "skos:prefLabel": "Morningside Heights YA Reference"
+    },
+    {
+      "@id": "nyplLocation:mm4a",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4a",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:pma0v",
@@ -13508,10 +13728,10 @@
       "skos:prefLabel": "Morrisania Adult Reference"
     },
     {
-      "@id": "nyplLocation:lma",
+      "@id": "nyplLocation:cly0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:lm"
+        "@id": "nyplLocation:cl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -13522,9 +13742,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "New Amsterdam Adult",
-      "skos:notation": "lma",
-      "skos:prefLabel": "New Amsterdam Adult"
+      "skos:altLabel": "Morningside Heights YA Non-Fiction",
+      "skos:notation": "cly0n",
+      "skos:prefLabel": "Morningside Heights YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:pma01",
@@ -13755,28 +13975,6 @@
       "skos:prefLabel": "Harlem Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:mma",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mm"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1500"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Mid-Manhattan Adult",
-      "skos:notation": "mma",
-      "skos:prefLabel": "Mid-Manhattan Adult"
-    },
-    {
       "@id": "nyplLocation:hlj0t",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -13813,25 +14011,6 @@
       "skos:altLabel": "Harlem Children's Non-Print Media",
       "skos:notation": "hlj0v",
       "skos:prefLabel": "Harlem Children's Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:wlj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Woodlawn Heights Children's Non-Print Media",
-      "skos:notation": "wlj0v",
-      "skos:prefLabel": "Woodlawn Heights Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:hlj0y",
@@ -14043,10 +14222,10 @@
       "skos:prefLabel": "Mulberry Street Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:clzzz",
+      "@id": "nyplLocation:mlj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cl"
+        "@id": "nyplLocation:ml"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -14057,9 +14236,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Morningside Heights (error code)",
-      "skos:notation": "clzzz",
-      "skos:prefLabel": "Morningside Heights"
+      "skos:altLabel": "Mulberry Street Children's Non-Print Media",
+      "skos:notation": "mlj0v",
+      "skos:prefLabel": "Mulberry Street Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:tga03",
@@ -14081,10 +14260,10 @@
       "skos:prefLabel": "Throg's Neck Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:tga01",
+      "@id": "nyplLocation:otzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
+        "@id": "nyplLocation:ot"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -14095,9 +14274,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Throg's Neck Reference",
-      "skos:notation": "tga01",
-      "skos:prefLabel": "Throg's Neck Reference"
+      "skos:altLabel": "Ottendorfer (error code)",
+      "skos:notation": "otzzz",
+      "skos:prefLabel": "Ottendorfer"
     },
     {
       "@id": "nyplLocation:jmy0v",
@@ -14256,10 +14435,10 @@
       "skos:prefLabel": "Schwarzman Building - Preservation"
     },
     {
-      "@id": "nyplLocation:eajr",
+      "@id": "nyplLocation:baj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:ba"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -14270,9 +14449,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Eastchester Children's Reference",
-      "skos:notation": "eajr",
-      "skos:prefLabel": "Eastchester Children's Reference"
+      "skos:altLabel": "Baychester Children's Non-Fiction",
+      "skos:notation": "baj0n",
+      "skos:prefLabel": "Baychester Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:baj0a",
@@ -14339,7 +14518,7 @@
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
@@ -14408,7 +14587,7 @@
       },
       "skos:altLabel": "SASB - Map Division - Rm 117",
       "skos:notation": "map",
-      "skos:prefLabel": "Schwarzman Building - Map Division - Room 117"
+      "skos:prefLabel": "Schwarzman Building - Map Division Room 117"
     },
     {
       "@id": "nyplLocation:huj0l",
@@ -14456,7 +14635,7 @@
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
@@ -15585,25 +15764,6 @@
       "skos:prefLabel": "Webster Children"
     },
     {
-      "@id": "nyplLocation:woj0h",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:wo"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Woodstock Children's Holiday Book",
-      "skos:notation": "woj0h",
-      "skos:prefLabel": "Woodstock Children's Holiday Book"
-    },
-    {
       "@id": "nyplLocation:wby",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -15756,7 +15916,26 @@
       "skos:prefLabel": "Kingsbridge Reference"
     },
     {
-      "@id": "nyplLocation:tgj0n",
+      "@id": "nyplLocation:epar",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ep"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Epiphany Adult Reference",
+      "skos:notation": "epar",
+      "skos:prefLabel": "Epiphany Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:tgj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:tg"
@@ -15770,15 +15949,15 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Throg's Neck Children's Non-Fiction",
-      "skos:notation": "tgj0n",
-      "skos:prefLabel": "Throg's Neck Children's Non-Fiction"
+      "skos:altLabel": "Throg's Neck Children's Picture Book",
+      "skos:notation": "tgj0i",
+      "skos:prefLabel": "Throg's Neck Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:kbj01",
+      "@id": "nyplLocation:hbj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:kb"
+        "@id": "nyplLocation:hb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -15789,28 +15968,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Kingsbridge Children's Reference",
-      "skos:notation": "kbj01",
-      "skos:prefLabel": "Kingsbridge Children's Reference"
-    },
-    {
-      "@id": "nyplLocation:mha0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mh"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Mott Haven Non-Print Media",
-      "skos:notation": "mha0v",
-      "skos:prefLabel": "Mott Haven Non-Print Media"
+      "skos:altLabel": "High Bridge Children's Non-Print Media",
+      "skos:notation": "hbj0v",
+      "skos:prefLabel": "High Bridge Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:mha0w",
@@ -16006,10 +16166,10 @@
       "skos:prefLabel": "High Bridge Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:hbj0f",
+      "@id": "nyplLocation:mha0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hb"
+        "@id": "nyplLocation:mh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16020,9 +16180,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "High Bridge Children's Fiction",
-      "skos:notation": "hbj0f",
-      "skos:prefLabel": "High Bridge Children's Fiction"
+      "skos:altLabel": "Mott Haven Fiction",
+      "skos:notation": "mha0f",
+      "skos:prefLabel": "Mott Haven Fiction"
     },
     {
       "@id": "nyplLocation:btyr",
@@ -16126,10 +16286,10 @@
       "skos:prefLabel": "Schwarzman Building - Photography Collection Room 308"
     },
     {
-      "@id": "nyplLocation:wta03",
+      "@id": "nyplLocation:pra0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:pr"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16140,9 +16300,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Westchester Square Closed Shelf Reference",
-      "skos:notation": "wta03",
-      "skos:prefLabel": "Westchester Square Closed Shelf Reference"
+      "skos:altLabel": "Port Richmond Fiction",
+      "skos:notation": "pra0f",
+      "skos:prefLabel": "Port Richmond Fiction"
     },
     {
       "@id": "nyplLocation:maf99",
@@ -16167,7 +16327,7 @@
       },
       "skos:altLabel": "SASB M2 - Dorot Jewish Division (Restricted) - Room 111",
       "skos:notation": "maf99",
-      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division (Restricted) - Room 111"
+      "skos:prefLabel": "Schwarzman Building M2 - Dorot Jewish Division (Restricted) Room 111"
     },
     {
       "@id": "nyplLocation:hsj0l",
@@ -16385,10 +16545,10 @@
       "skos:prefLabel": "Fort Washington Young Adult Reference"
     },
     {
-      "@id": "nyplLocation:tsy0l",
+      "@id": "nyplLocation:wfj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
+        "@id": "nyplLocation:wf"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16399,15 +16559,15 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Tompkins Square YA World Languages",
-      "skos:notation": "tsy0l",
-      "skos:prefLabel": "Tompkins Square YA World Languages"
+      "skos:altLabel": "West Farms Children's Non-Fiction",
+      "skos:notation": "wfj0n",
+      "skos:prefLabel": "West Farms Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:bla01",
+      "@id": "nyplLocation:fey",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:bl"
+        "@id": "nyplLocation:fe"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16418,9 +16578,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Bloomingdale Reference",
-      "skos:notation": "bla01",
-      "skos:prefLabel": "Bloomingdale Reference"
+      "skos:altLabel": "58th Street Young Adult",
+      "skos:notation": "fey",
+      "skos:prefLabel": "58th Street Young Adult"
     },
     {
       "@id": "nyplLocation:clj0i",
@@ -16442,10 +16602,10 @@
       "skos:prefLabel": "Morningside Heights Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:svj",
+      "@id": "nyplLocation:clj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sv"
+        "@id": "nyplLocation:cl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16456,9 +16616,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Soundview Children",
-      "skos:notation": "svj",
-      "skos:prefLabel": "Soundview Children"
+      "skos:altLabel": "Morningside Heights Children's Holiday Book",
+      "skos:notation": "clj0h",
+      "skos:prefLabel": "Morningside Heights Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:clj0n",
@@ -16649,6 +16809,25 @@
       "skos:altLabel": "Morningside Heights Children's Young Reader",
       "skos:notation": "clj0y",
       "skos:prefLabel": "Morningside Heights Children's Young Reader"
+    },
+    {
+      "@id": "nyplLocation:tha01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:th"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Todt Hill-Westerleigh Reference",
+      "skos:notation": "tha01",
+      "skos:prefLabel": "Todt Hill-Westerleigh Reference"
     },
     {
       "@id": "nyplLocation:cijr",
@@ -16917,10 +17096,10 @@
       "skos:prefLabel": "Epiphany Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:pra03",
+      "@id": "nyplLocation:yva",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:yv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -16931,9 +17110,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Port Richmond Closed Shelf Reference",
-      "skos:notation": "pra03",
-      "skos:prefLabel": "Port Richmond Closed Shelf Reference"
+      "skos:altLabel": "Yorkville Adult",
+      "skos:notation": "yva",
+      "skos:prefLabel": "Yorkville Adult"
     },
     {
       "@id": "nyplLocation:maj0a",
@@ -17072,25 +17251,6 @@
       "skos:prefLabel": "West Farms Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:prj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Port Richmond Children's Non-Print Media",
-      "skos:notation": "prj0v",
-      "skos:prefLabel": "Port Richmond Children's Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:wtj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -17192,10 +17352,10 @@
       "skos:prefLabel": "Temporary Storage"
     },
     {
-      "@id": "nyplLocation:pkar",
+      "@id": "nyplLocation:sgj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:sg"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -17206,9 +17366,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Parkchester Adult Reference",
-      "skos:notation": "pkar",
-      "skos:prefLabel": "Parkchester Adult Reference"
+      "skos:altLabel": "St. George Children's Easy Book",
+      "skos:notation": "sgj0a",
+      "skos:prefLabel": "St. George Children's Easy Book"
     },
     {
       "@id": "nyplLocation:ota0l",
@@ -17344,10 +17504,10 @@
       "skos:prefLabel": "New Dorp Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:ota0f",
+      "@id": "nyplLocation:sga0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:sg"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -17358,9 +17518,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Ottendorfer Fiction",
-      "skos:notation": "ota0f",
-      "skos:prefLabel": "Ottendorfer Fiction"
+      "skos:altLabel": "St. George Center for Reading & Writing",
+      "skos:notation": "sga0w",
+      "skos:prefLabel": "St. George Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:sga0v",
@@ -17756,8 +17916,8 @@
         "@value": "true"
       },
       "nypl:collectionType": [
-        "Research",
-        "Branch"
+        "Branch",
+        "Research"
       ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
@@ -17809,10 +17969,10 @@
       "skos:prefLabel": "Research Libraries - On Order"
     },
     {
-      "@id": "nyplLocation:fea",
+      "@id": "nyplLocation:sgj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:sg"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -17823,9 +17983,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "58th Street Adult",
-      "skos:notation": "fea",
-      "skos:prefLabel": "58th Street Adult"
+      "skos:altLabel": "St. George Children's Non-Print Media",
+      "skos:notation": "sgj0v",
+      "skos:prefLabel": "St. George Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:vnj",
@@ -18028,6 +18188,25 @@
       "skos:altLabel": "Great Kills Young Adult",
       "skos:notation": "gky",
       "skos:prefLabel": "Great Kills Young Adult"
+    },
+    {
+      "@id": "nyplLocation:epy01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ep"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Epiphany YA Reference",
+      "skos:notation": "epy01",
+      "skos:prefLabel": "Epiphany YA Reference"
     },
     {
       "@id": "nyplLocation:ndj01",
@@ -18429,6 +18608,28 @@
       "skos:prefLabel": "George Bruce Children's Easy Book"
     },
     {
+      "@id": "nyplLocation:mm4yf",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4yf",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
       "@id": "nyplLocation:brj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -18495,6 +18696,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -18545,10 +18747,10 @@
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral YA Fiction"
     },
     {
-      "@id": "nyplLocation:ina",
+      "@id": "nyplLocation:nsy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:in"
+        "@id": "nyplLocation:ns"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -18559,9 +18761,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Inwood Adult",
-      "skos:notation": "ina",
-      "skos:prefLabel": "Inwood Adult"
+      "skos:altLabel": "96th Street YA Fiction",
+      "skos:notation": "nsy0f",
+      "skos:prefLabel": "96th Street YA Fiction"
     },
     {
       "@id": "nyplLocation:bly0f",
@@ -18886,6 +19088,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -19373,6 +19576,25 @@
       "skos:prefLabel": "Chatham Square YA Fiction"
     },
     {
+      "@id": "nyplLocation:eay",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ea"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Eastchester Young Adult",
+      "skos:notation": "eay",
+      "skos:prefLabel": "Eastchester Young Adult"
+    },
+    {
       "@id": "nyplLocation:pmy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -19449,10 +19671,10 @@
       "skos:prefLabel": "Throg's Neck Children's Reference"
     },
     {
-      "@id": "nyplLocation:hly01",
+      "@id": "nyplLocation:brj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hl"
+        "@id": "nyplLocation:br"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -19463,9 +19685,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Harlem YA Reference",
-      "skos:notation": "hly01",
-      "skos:prefLabel": "Harlem YA Reference"
+      "skos:altLabel": "George Bruce Children",
+      "skos:notation": "brj",
+      "skos:prefLabel": "George Bruce Children"
     },
     {
       "@id": "nyplLocation:maj0t",
@@ -19513,6 +19735,28 @@
       "skos:altLabel": "Performing Arts Research Collections - Theatre",
       "skos:notation": "myt38",
       "skos:prefLabel": "Performing Arts Research Collections  Theatre"
+    },
+    {
+      "@id": "nyplLocation:mm2yn",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2yn",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:pmy01",
@@ -19657,25 +19901,6 @@
       "skos:prefLabel": "Offsite"
     },
     {
-      "@id": "nyplLocation:gka0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:gk"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Great Kills Non-Fiction",
-      "skos:notation": "gka0n",
-      "skos:prefLabel": "Great Kills Non-Fiction"
-    },
-    {
       "@id": "nyplLocation:rcpd9",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -19739,6 +19964,28 @@
       "skos:prefLabel": "Morningside Heights Fiction"
     },
     {
+      "@id": "nyplLocation:mma2f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Fiction Second Floor",
+      "skos:notation": "mma2f",
+      "skos:prefLabel": "Mid-Manhattan Fiction Second Floor"
+    },
+    {
       "@id": "nyplLocation:hly0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -19777,10 +20024,10 @@
       "skos:prefLabel": "Harlem YA World Languages"
     },
     {
-      "@id": "nyplLocation:eaj",
+      "@id": "nyplLocation:kbj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:kb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -19791,9 +20038,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Eastchester Children",
-      "skos:notation": "eaj",
-      "skos:prefLabel": "Eastchester Children"
+      "skos:altLabel": "Kingsbridge Children's Easy Book",
+      "skos:notation": "kbj0a",
+      "skos:prefLabel": "Kingsbridge Children's Easy Book"
     },
     {
       "@id": "nyplLocation:hly0f",
@@ -19894,7 +20141,45 @@
       },
       "skos:altLabel": "SASB M2 - General Research - Room 315",
       "skos:notation": "mai92",
-      "skos:prefLabel": "Schwarzman Building M2 - General Research - Room 315"
+      "skos:prefLabel": "Schwarzman Building M2 - General Research Room 315"
+    },
+    {
+      "@id": "nyplLocation:wtj0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wt"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Westchester Square Children's Fiction",
+      "skos:notation": "wtj0f",
+      "skos:prefLabel": "Westchester Square Children's Fiction"
+    },
+    {
+      "@id": "nyplLocation:nsj",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ns"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "96th Street Children",
+      "skos:notation": "nsj",
+      "skos:prefLabel": "96th Street Children"
     },
     {
       "@id": "nyplLocation:blyr",
@@ -19925,6 +20210,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -20231,7 +20517,7 @@
       "skos:prefLabel": "Yorkville Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:dhar",
+      "@id": "nyplLocation:dhj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:dh"
@@ -20245,9 +20531,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Dongan Hills Adult Reference",
-      "skos:notation": "dhar",
-      "skos:prefLabel": "Dongan Hills Adult Reference"
+      "skos:altLabel": "Dongan Hills Children's Holiday Book",
+      "skos:notation": "dhj0h",
+      "skos:prefLabel": "Dongan Hills Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:clyr",
@@ -20286,25 +20572,6 @@
       "skos:altLabel": "Harlem Adult",
       "skos:notation": "hla",
       "skos:prefLabel": "Harlem Adult"
-    },
-    {
-      "@id": "nyplLocation:tvj0y",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:tv"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Tottenville Children's Young Reader",
-      "skos:notation": "tvj0y",
-      "skos:prefLabel": "Tottenville Children's Young Reader"
     },
     {
       "@id": "nyplLocation:cpa",
@@ -20516,10 +20783,10 @@
       "skos:prefLabel": "Belmont Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:mna",
+      "@id": "nyplLocation:dhj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mn"
+        "@id": "nyplLocation:dh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -20530,9 +20797,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mariner's Harbor Adult",
-      "skos:notation": "mna",
-      "skos:prefLabel": "Mariner's Harbor Adult"
+      "skos:altLabel": "Dongan Hills Children's Non-Fiction",
+      "skos:notation": "dhj0n",
+      "skos:prefLabel": "Dongan Hills Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:wtjr",
@@ -20844,29 +21111,23 @@
       "skos:prefLabel": "Woodlawn Heights YA Fiction"
     },
     {
-      "@id": "nyplLocation:mym28",
+      "@id": "nyplLocation:gka0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
+        "@id": "nyplLocation:gk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1123"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Performing Arts Research Collections - Music",
-      "skos:notation": "mym28",
-      "skos:prefLabel": "Performing Arts Research Collections - Music"
+      "skos:altLabel": "Great Kills Non-Fiction",
+      "skos:notation": "gka0n",
+      "skos:prefLabel": "Great Kills Non-Fiction"
     },
     {
       "@id": "nyplLocation:myar1",
@@ -21014,10 +21275,10 @@
       "skos:prefLabel": "Schwarzman Building (Children's Center at 42nd St.) - Young Reader Room 84"
     },
     {
-      "@id": "nyplLocation:eaar",
+      "@id": "nyplLocation:dhj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:dh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -21028,9 +21289,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Eastchester Adult Reference",
-      "skos:notation": "eaar",
-      "skos:prefLabel": "Eastchester Adult Reference"
+      "skos:altLabel": "Dongan Hills Children's Non-Print Media",
+      "skos:notation": "dhj0v",
+      "skos:prefLabel": "Dongan Hills Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:tvy01",
@@ -21109,7 +21370,10 @@
       },
       "skos:altLabel": "Mid-Manhattan (error code)",
       "skos:notation": "mmzzz",
-      "skos:prefLabel": "Mid-Manhattan"
+      "skos:prefLabel": [
+        "Mid-Manhattan",
+        "Mid-Manhattan (error code)"
+      ]
     },
     {
       "@id": "nyplLocation:hk",
@@ -21549,10 +21813,10 @@
       "skos:prefLabel": "Jerome Park Adult Reference"
     },
     {
-      "@id": "nyplLocation:fwj0n",
+      "@id": "nyplLocation:tvy0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fw"
+        "@id": "nyplLocation:tv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -21563,9 +21827,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Fort Washington Children's Non-Fiction",
-      "skos:notation": "fwj0n",
-      "skos:prefLabel": "Fort Washington Children's Non-Fiction"
+      "skos:altLabel": "Tottenville YA Non-Fiction",
+      "skos:notation": "tvy0n",
+      "skos:prefLabel": "Tottenville YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:tvy0v",
@@ -21606,10 +21870,10 @@
       "skos:prefLabel": "Chatham Square"
     },
     {
-      "@id": "nyplLocation:eaa0f",
+      "@id": "nyplLocation:ala01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:al"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -21620,9 +21884,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Eastchester Fiction",
-      "skos:notation": "eaa0f",
-      "skos:prefLabel": "Eastchester Fiction"
+      "skos:altLabel": "Allerton Reference",
+      "skos:notation": "ala01",
+      "skos:prefLabel": "Allerton Reference"
     },
     {
       "@id": "nyplLocation:moyr",
@@ -22081,23 +22345,26 @@
       "skos:prefLabel": "Van Cortlandt YA Fiction"
     },
     {
-      "@id": "nyplLocation:tha0f",
+      "@id": "nyplLocation:mm5av",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:th"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Todt Hill-Westerleigh Fiction",
-      "skos:notation": "tha0f",
-      "skos:prefLabel": "Todt Hill-Westerleigh Fiction"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm5av",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:vcy0l",
@@ -22290,23 +22557,26 @@
       "skos:prefLabel": "Mott Haven Children's Reference"
     },
     {
-      "@id": "nyplLocation:gdy",
+      "@id": "nyplLocation:rc",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gd"
+        "@id": "nyplLocation:rc"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/0001"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
-        "@value": "false"
+        "@value": "true"
       },
-      "skos:altLabel": "Grand Concourse Young Adult",
-      "skos:notation": "gdy",
-      "skos:prefLabel": "Grand Concourse Young Adult"
+      "skos:altLabel": "NYPL Research Libraries",
+      "skos:notation": "rc",
+      "skos:prefLabel": "Offsite"
     },
     {
       "@id": "nyplLocation:gdy0v",
@@ -22385,36 +22655,6 @@
       "skos:prefLabel": "Hamilton Fish Park"
     },
     {
-      "@id": "nyplLocation:sce",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:deliveryLocationType": "Research",
-      "nypl:locationsSlug": "photographs-and-prints-division",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1118"
-      },
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SP"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Schomburg Center - Photographs & Prints",
-      "skos:notation": "sce",
-      "skos:prefLabel": "Schomburg Center - Photographs & Prints"
-    },
-    {
       "@id": "nyplLocation:vcy01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -22470,6 +22710,28 @@
       "skos:altLabel": "Hamilton Grange Children's Reference",
       "skos:notation": "hgjr",
       "skos:prefLabel": "Hamilton Grange Children's Reference"
+    },
+    {
+      "@id": "nyplLocation:mm4yn",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4yn",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:bazzz",
@@ -22736,6 +22998,25 @@
       "skos:altLabel": "Chatham Square Children's World Languages",
       "skos:notation": "chj0l",
       "skos:prefLabel": "Chatham Square Children's World Languages"
+    },
+    {
+      "@id": "nyplLocation:pra03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:pr"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Port Richmond Closed Shelf Reference",
+      "skos:notation": "pra03",
+      "skos:prefLabel": "Port Richmond Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:chj0i",
@@ -23111,34 +23392,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
+          "@id": "nyplLocation:mal"
+        },
+        {
           "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:maln"
         },
         {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:malc"
         },
         {
           "@id": "nyplLocation:mab"
         },
         {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:mala"
         }
       ],
       "nypl:owner": {
@@ -23150,13 +23431,13 @@
       },
       "skos:altLabel": "SASB M2 - Milstein Division - Room 121",
       "skos:notation": "mag92",
-      "skos:prefLabel": "Schwarzman Building M2 - Milstein Division - Room 121"
+      "skos:prefLabel": "Schwarzman Building M2 - Milstein Division Room 121"
     },
     {
-      "@id": "nyplLocation:kby01",
+      "@id": "nyplLocation:saa0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:kb"
+        "@id": "nyplLocation:sa"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -23167,9 +23448,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Kingsbridge YA Reference",
-      "skos:notation": "kby01",
-      "skos:prefLabel": "Kingsbridge YA Reference"
+      "skos:altLabel": "St. Agnes Fiction",
+      "skos:notation": "saa0f",
+      "skos:prefLabel": "St. Agnes Fiction"
     },
     {
       "@id": "nyplLocation:tgy01",
@@ -23376,7 +23657,7 @@
       },
       "skos:altLabel": "SASB M2 - Milstein Division - Room 121",
       "skos:notation": "mag98",
-      "skos:prefLabel": "Schwarzman Building M2 - Milstein Division - Room 121"
+      "skos:prefLabel": "Schwarzman Building M2 - Milstein Division Room 121"
     },
     {
       "@id": "nyplLocation:moa0l",
@@ -23646,9 +23927,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "mai87",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 119"
     },
     {
       "@id": "nyplLocation:muy",
@@ -23728,9 +24009,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "mai83",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 119"
     },
     {
       "@id": "nyplLocation:mai82",
@@ -23753,9 +24034,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB M1 - Periodicals and Microforms Rm 100",
+      "skos:altLabel": "SASB M1 - Periodicals and Microforms Rm 119",
       "skos:notation": "mai82",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 119"
     },
     {
       "@id": "nyplLocation:wha0l",
@@ -23815,10 +24096,10 @@
       "skos:prefLabel": "Washington Heights Non-Fiction"
     },
     {
-      "@id": "nyplLocation:mua0l",
+      "@id": "nyplLocation:pry0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:pr"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -23829,9 +24110,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Muhlenberg World Languages",
-      "skos:notation": "mua0l",
-      "skos:prefLabel": "Muhlenberg World Languages"
+      "skos:altLabel": "Port Richmond YA Fiction",
+      "skos:notation": "pry0f",
+      "skos:prefLabel": "Port Richmond YA Fiction"
     },
     {
       "@id": "nyplLocation:muj",
@@ -24283,10 +24564,10 @@
       "skos:prefLabel": "Westchester Square YA World Languages"
     },
     {
-      "@id": "nyplLocation:gdj0v",
+      "@id": "nyplLocation:mhj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gd"
+        "@id": "nyplLocation:mh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -24297,9 +24578,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Grand Concourse Children's Non-Print Media",
-      "skos:notation": "gdj0v",
-      "skos:prefLabel": "Grand Concourse Children's Non-Print Media"
+      "skos:altLabel": "Mott Haven Children's Young Reader",
+      "skos:notation": "mhj0y",
+      "skos:prefLabel": "Mott Haven Children's Young Reader"
     },
     {
       "@id": "nyplLocation:wty0n",
@@ -24532,10 +24813,10 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mag"
         }
       ],
       "nypl:owner": {
@@ -24547,7 +24828,7 @@
       },
       "skos:altLabel": "SASB - Milstein Division - Mezzanine",
       "skos:notation": "magg2",
-      "skos:prefLabel": "Schwarzman Building - Milstein Division - Mezzanine"
+      "skos:prefLabel": "Schwarzman Building - Milstein Division Mezzanine Room 121"
     },
     {
       "@id": "nyplLocation:magg3",
@@ -24562,10 +24843,10 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mag"
         }
       ],
       "nypl:owner": {
@@ -24577,7 +24858,7 @@
       },
       "skos:altLabel": "SASB - Milstein Division - Desk Rm 121",
       "skos:notation": "magg3",
-      "skos:prefLabel": "Schwarzman Building - Milstein Division - Desk Room 121"
+      "skos:prefLabel": "Schwarzman Building - Milstein Division Desk Room 121"
     },
     {
       "@id": "nyplLocation:gdj0a",
@@ -24611,10 +24892,10 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mag"
+          "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mal"
+          "@id": "nyplLocation:mag"
         }
       ],
       "nypl:owner": {
@@ -24809,27 +25090,6 @@
       "skos:prefLabel": "Schwarzman Building S6 - Art & Architecture Room 300"
     },
     {
-      "@id": "nyplLocation:may",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1000"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "SASB - DO NOT USE",
-      "skos:notation": "may",
-      "skos:prefLabel": "Schwarzman Building"
-    },
-    {
       "@id": "nyplLocation:caj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -24963,10 +25223,10 @@
       "skos:prefLabel": "Great Kills Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:caj0h",
+      "@id": "nyplLocation:csj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ca"
+        "@id": "nyplLocation:cs"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -24977,9 +25237,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Children's Holiday Book",
-      "skos:notation": "caj0h",
-      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Holiday Book"
+      "skos:altLabel": "Columbus Children's Non-Print Media",
+      "skos:notation": "csj0v",
+      "skos:prefLabel": "Columbus Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:caj0i",
@@ -25058,10 +25318,10 @@
       "skos:prefLabel": "Great Kills Children's Fiction"
     },
     {
-      "@id": "nyplLocation:bry01",
+      "@id": "nyplLocation:caj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:br"
+        "@id": "nyplLocation:ca"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -25072,9 +25332,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "George Bruce YA Reference",
-      "skos:notation": "bry01",
-      "skos:prefLabel": "George Bruce YA Reference"
+      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media",
+      "skos:notation": "caj0v",
+      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:csj0i",
@@ -25599,29 +25859,23 @@
       "skos:prefLabel": "Performing Arts Research Collections - Theatre"
     },
     {
-      "@id": "nyplLocation:mau",
+      "@id": "nyplLocation:rtj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ma"
+        "@id": "nyplLocation:rt"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:mau"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1112"
-      },
+      "nypl:collectionType": "Branch",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "SASB - Print Collection Rm 308",
-      "skos:notation": "mau",
-      "skos:prefLabel": "Schwarzman Building - Print Collection Room 308"
+      "skos:altLabel": "Richmondtown Children",
+      "skos:notation": "rtj",
+      "skos:prefLabel": "Richmondtown Children"
     },
     {
       "@id": "nyplLocation:ij",
@@ -25728,6 +25982,10 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": [
+        "Research",
+        "Branch"
+      ],
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
@@ -25756,23 +26014,26 @@
       "skos:prefLabel": "South Beach Children"
     },
     {
-      "@id": "nyplLocation:bey0v",
+      "@id": "nyplLocation:myav3",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:be"
+        "@id": "nyplLocation:my"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Belmont YA Non-Print Media",
-      "skos:notation": "bey0v",
-      "skos:prefLabel": "Belmont YA Non-Print Media"
+      "skos:altLabel": "Performing Arts Closed Shelf Reference Recorded Media",
+      "skos:notation": "myav3",
+      "skos:prefLabel": "Performing Arts Closed Shelf Reference Recorded Media"
     },
     {
       "@id": "nyplLocation:pmj01",
@@ -25852,6 +26113,25 @@
       "skos:altLabel": "OFFSITE - Performing Arts--Offsite--Restricted Use",
       "skos:notation": "rcpr9",
       "skos:prefLabel": "Offsite"
+    },
+    {
+      "@id": "nyplLocation:pky0n",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:pk"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Parkchester YA Non-Fiction",
+      "skos:notation": "pky0n",
+      "skos:prefLabel": "Parkchester YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:aly0v",
@@ -25966,6 +26246,25 @@
       "skos:altLabel": "Allerton YA World Languages",
       "skos:notation": "aly0l",
       "skos:prefLabel": "Allerton YA World Languages"
+    },
+    {
+      "@id": "nyplLocation:hty0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ht"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Countee Cullen YA Non-Print Media",
+      "skos:notation": "hty0v",
+      "skos:prefLabel": "Countee Cullen YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:bey0n",
@@ -26101,10 +26400,10 @@
       "skos:prefLabel": "Parkchester YA Non-Print Media"
     },
     {
-      "@id": "nyplLocation:fty0v",
+      "@id": "nyplLocation:jmj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ft"
+        "@id": "nyplLocation:jm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -26115,9 +26414,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "53rd Street YA Non-Print Media",
-      "skos:notation": "fty0v",
-      "skos:prefLabel": "53rd Street YA Non-Print Media"
+      "skos:altLabel": "Jefferson Market Children's Fiction",
+      "skos:notation": "jmj0f",
+      "skos:prefLabel": "Jefferson Market Children's Fiction"
     },
     {
       "@id": "nyplLocation:sda0f",
@@ -26222,7 +26521,7 @@
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": {
@@ -26333,10 +26632,10 @@
       "skos:prefLabel": "St. George YA Fiction"
     },
     {
-      "@id": "nyplLocation:cly0n",
+      "@id": "nyplLocation:lma",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cl"
+        "@id": "nyplLocation:lm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -26347,9 +26646,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Morningside Heights YA Non-Fiction",
-      "skos:notation": "cly0n",
-      "skos:prefLabel": "Morningside Heights YA Non-Fiction"
+      "skos:altLabel": "New Amsterdam Adult",
+      "skos:notation": "lma",
+      "skos:prefLabel": "New Amsterdam Adult"
     },
     {
       "@id": "nyplLocation:sgy0l",
@@ -26447,6 +26746,25 @@
       "skos:prefLabel": "Sedgwick Closed Shelf Reference"
     },
     {
+      "@id": "nyplLocation:sdj01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:sd"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Sedgwick Children's Reference",
+      "skos:notation": "sdj01",
+      "skos:prefLabel": "Sedgwick Children's Reference"
+    },
+    {
       "@id": "nyplLocation:bla",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -26466,10 +26784,10 @@
       "skos:prefLabel": "Bloomingdale Adult"
     },
     {
-      "@id": "nyplLocation:pky0l",
+      "@id": "nyplLocation:mua03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:mu"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -26480,9 +26798,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Parkchester YA World Languages",
-      "skos:notation": "pky0l",
-      "skos:prefLabel": "Parkchester YA World Languages"
+      "skos:altLabel": "Muhlenberg Closed Shelf Reference",
+      "skos:notation": "mua03",
+      "skos:prefLabel": "Muhlenberg Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:bly",
@@ -26548,6 +26866,25 @@
       "skos:prefLabel": "Schomburg Center - Moving Image & Recorded Sound"
     },
     {
+      "@id": "nyplLocation:chyr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ch"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Chatham Square Young Adult Reference",
+      "skos:notation": "chyr",
+      "skos:prefLabel": "Chatham Square Young Adult Reference"
+    },
+    {
       "@id": "nyplLocation:char",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -26605,10 +26942,10 @@
       "skos:prefLabel": "Harlem Non-Fiction"
     },
     {
-      "@id": "nyplLocation:hla0l",
+      "@id": "nyplLocation:sey0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hl"
+        "@id": "nyplLocation:se"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -26619,9 +26956,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Harlem World Languages",
-      "skos:notation": "hla0l",
-      "skos:prefLabel": "Harlem World Languages"
+      "skos:altLabel": "Seward Park YA Non-Fiction",
+      "skos:notation": "sey0n",
+      "skos:prefLabel": "Seward Park YA Non-Fiction"
     },
     {
       "@id": "nyplLocation:hla0w",
@@ -27061,6 +27398,25 @@
       "skos:prefLabel": "Parkchester Children's Young Reader"
     },
     {
+      "@id": "nyplLocation:sey0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:se"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Seward Park YA Non-Print Media",
+      "skos:notation": "sey0v",
+      "skos:prefLabel": "Seward Park YA Non-Print Media"
+    },
+    {
       "@id": "nyplLocation:hgzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -27174,6 +27530,10 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": [
+        "Research",
+        "Branch"
+      ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -27614,6 +27974,25 @@
       "skos:prefLabel": "Great Kills YA Non-Fiction"
     },
     {
+      "@id": "nyplLocation:hgj01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:hg"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Hamilton Grange Children's Reference",
+      "skos:notation": "hgj01",
+      "skos:prefLabel": "Hamilton Grange Children's Reference"
+    },
+    {
       "@id": "nyplLocation:hbar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -27707,25 +28086,6 @@
       "skos:altLabel": "Washington Heights Fiction",
       "skos:notation": "wha0f",
       "skos:prefLabel": "Washington Heights Fiction"
-    },
-    {
-      "@id": "nyplLocation:sbj0i",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sb"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "South Beach Children's Picture Book",
-      "skos:notation": "sbj0i",
-      "skos:prefLabel": "South Beach Children's Picture Book"
     },
     {
       "@id": "nyplLocation:wla0f",
@@ -27823,10 +28183,10 @@
       "skos:prefLabel": "Tottenville Reference"
     },
     {
-      "@id": "nyplLocation:tva03",
+      "@id": "nyplLocation:wla0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tv"
+        "@id": "nyplLocation:wl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -27837,9 +28197,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Tottenville Closed Shelf Reference",
-      "skos:notation": "tva03",
-      "skos:prefLabel": "Tottenville Closed Shelf Reference"
+      "skos:altLabel": "Woodlawn Heights Non-Print Media",
+      "skos:notation": "wla0v",
+      "skos:prefLabel": "Woodlawn Heights Non-Print Media"
     },
     {
       "@id": "nyplLocation:gky01",
@@ -27880,10 +28240,10 @@
       "skos:prefLabel": "Jerome Park Children's Reference"
     },
     {
-      "@id": "nyplLocation:pry0f",
+      "@id": "nyplLocation:ciyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:ci"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -27894,9 +28254,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Port Richmond YA Fiction",
-      "skos:notation": "pry0f",
-      "skos:prefLabel": "Port Richmond YA Fiction"
+      "skos:altLabel": "City Island Young Adult Reference",
+      "skos:notation": "ciyr",
+      "skos:prefLabel": "City Island Young Adult Reference"
     },
     {
       "@id": "nyplLocation:tva0l",
@@ -28765,27 +29125,59 @@
       "skos:prefLabel": "ReCAP/Princeton Preservation"
     },
     {
-      "@id": "nyplLocation:x001",
+      "@id": "nyplLocation:x007",
       "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:my"
+      },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
       "nypl:collectionType": "Research",
       "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
       "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/IN"
+        "@id": "http://data.nypl.org/recapCustomerCodes/OP"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "ReCAP Inter-Library Loan",
-      "skos:notation": "x001",
-      "skos:prefLabel": "ReCAP Inter-Library Loan"
+      "skos:altLabel": "LPA no Sierra holds",
+      "skos:notation": "x007",
+      "skos:prefLabel": "LPA no Sierra holds"
     },
     {
-      "@id": "nyplLocation:why0n",
+      "@id": "nyplLocation:x006",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ma"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/OS"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "SASB no Sierra holds",
+      "skos:notation": "x006",
+      "skos:prefLabel": "SASB no Sierra holds (discontinued)"
+    },
+    {
+      "@id": "nyplLocation:why0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:wh"
@@ -28799,9 +29191,29 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Washington Heights YA Non-Fiction",
-      "skos:notation": "why0n",
-      "skos:prefLabel": "Washington Heights YA Non-Fiction"
+      "skos:altLabel": "Washington Heights YA World Languages",
+      "skos:notation": "why0l",
+      "skos:prefLabel": "Washington Heights YA World Languages"
+    },
+    {
+      "@id": "nyplLocation:x003",
+      "@type": "nypl:Location",
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/RR"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "ReCAP Reading Room",
+      "skos:notation": "x003",
+      "skos:prefLabel": "ReCAP Reading Room"
     },
     {
       "@id": "nyplLocation:x002",
@@ -28862,6 +29274,32 @@
       "skos:prefLabel": "Hamilton Grange Non-Print Media"
     },
     {
+      "@id": "nyplLocation:x008",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:sl"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1125"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/OB"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "SIBL no Sierra holds",
+      "skos:notation": "x008",
+      "skos:prefLabel": "SIBL no Sierra holds"
+    },
+    {
       "@id": "nyplLocation:why0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -28909,6 +29347,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -28940,10 +29379,10 @@
       "skos:prefLabel": "67th Street Young Adult"
     },
     {
-      "@id": "nyplLocation:mlj0v",
+      "@id": "nyplLocation:bay01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ml"
+        "@id": "nyplLocation:ba"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -28954,9 +29393,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mulberry Street Children's Non-Print Media",
-      "skos:notation": "mlj0v",
-      "skos:prefLabel": "Mulberry Street Children's Non-Print Media"
+      "skos:altLabel": "Baychester YA Reference",
+      "skos:notation": "bay01",
+      "skos:prefLabel": "Baychester YA Reference"
     },
     {
       "@id": "nyplLocation:lbj01",
@@ -28995,6 +29434,25 @@
       "skos:altLabel": "67th Street Children",
       "skos:notation": "ssj",
       "skos:prefLabel": "67th Street Children"
+    },
+    {
+      "@id": "nyplLocation:tsjr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ts"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Tompkins Square Children's Reference",
+      "skos:notation": "tsjr",
+      "skos:prefLabel": "Tompkins Square Children's Reference"
     },
     {
       "@id": "nyplLocation:mny",
@@ -29149,10 +29607,10 @@
       "skos:prefLabel": "Hudson Park Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:otzzz",
+      "@id": "nyplLocation:tga01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:tg"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -29163,9 +29621,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Ottendorfer (error code)",
-      "skos:notation": "otzzz",
-      "skos:prefLabel": "Ottendorfer"
+      "skos:altLabel": "Throg's Neck Reference",
+      "skos:notation": "tga01",
+      "skos:prefLabel": "Throg's Neck Reference"
     },
     {
       "@id": "nyplLocation:hpj0h",
@@ -29244,10 +29702,10 @@
       "skos:prefLabel": "Hudson Park Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:wtj0f",
+      "@id": "nyplLocation:yvjr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wt"
+        "@id": "nyplLocation:yv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -29258,9 +29716,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Westchester Square Children's Fiction",
-      "skos:notation": "wtj0f",
-      "skos:prefLabel": "Westchester Square Children's Fiction"
+      "skos:altLabel": "Yorkville Children's Reference",
+      "skos:notation": "yvjr",
+      "skos:prefLabel": "Yorkville Children's Reference"
     },
     {
       "@id": "nyplLocation:hpj0v",
@@ -29472,10 +29930,10 @@
       "skos:prefLabel": "Great Kills Children's Reference"
     },
     {
-      "@id": "nyplLocation:otj0v",
+      "@id": "nyplLocation:sea0w",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:se"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -29486,9 +29944,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Ottendorfer Children's Non-Print Media",
-      "skos:notation": "otj0v",
-      "skos:prefLabel": "Ottendorfer Children's Non-Print Media"
+      "skos:altLabel": "Seward Park Center for Reading & Writing",
+      "skos:notation": "sea0w",
+      "skos:prefLabel": "Seward Park Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:otj0t",
@@ -29548,10 +30006,10 @@
       "skos:prefLabel": "West New Brighton Non-Fiction"
     },
     {
-      "@id": "nyplLocation:otj0l",
+      "@id": "nyplLocation:nba0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ot"
+        "@id": "nyplLocation:nb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -29562,9 +30020,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Ottendorfer Children's World Languages",
-      "skos:notation": "otj0l",
-      "skos:prefLabel": "Ottendorfer Children's World Languages"
+      "skos:altLabel": "West New Brighton World Languages",
+      "skos:notation": "nba0l",
+      "skos:prefLabel": "West New Brighton World Languages"
     },
     {
       "@id": "nyplLocation:wka03",
@@ -29991,23 +30449,26 @@
       "skos:prefLabel": "Huguenot Park Fiction"
     },
     {
-      "@id": "nyplLocation:baj0n",
+      "@id": "nyplLocation:may",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ba"
+        "@id": "nyplLocation:ma"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Baychester Children's Non-Fiction",
-      "skos:notation": "baj0n",
-      "skos:prefLabel": "Baychester Children's Non-Fiction"
+      "skos:altLabel": "SASB - DO NOT USE",
+      "skos:notation": "may",
+      "skos:prefLabel": "Schwarzman Building"
     },
     {
       "@id": "nyplLocation:nba03",
@@ -30029,10 +30490,10 @@
       "skos:prefLabel": "West New Brighton Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:nba01",
+      "@id": "nyplLocation:otj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
+        "@id": "nyplLocation:ot"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -30043,9 +30504,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West New Brighton Reference",
-      "skos:notation": "nba01",
-      "skos:prefLabel": "West New Brighton Reference"
+      "skos:altLabel": "Ottendorfer Children's Reference",
+      "skos:notation": "otj01",
+      "skos:prefLabel": "Ottendorfer Children's Reference"
     },
     {
       "@id": "nyplLocation:hka0v",
@@ -30103,25 +30564,6 @@
       "skos:altLabel": "Morrisania Young Adult Reference",
       "skos:notation": "mryr",
       "skos:prefLabel": "Morrisania Young Adult Reference"
-    },
-    {
-      "@id": "nyplLocation:tsa0w",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Tompkins Square Center for Reading & Writing",
-      "skos:notation": "tsa0w",
-      "skos:prefLabel": "Tompkins Square Center for Reading & Writing"
     },
     {
       "@id": "nyplLocation:mas",
@@ -30200,43 +30642,43 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:sc"
         },
         {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:malc"
+          "@id": "nyplLocation:map"
         },
         {
           "@id": "nyplLocation:maln"
         },
         {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
           "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:slr"
         },
         {
           "@id": "nyplLocation:myr"
         },
         {
           "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:slr"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:sc"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maf"
         }
       ],
       "nypl:owner": {
@@ -30268,6 +30710,25 @@
       "skos:altLabel": "Melrose Children",
       "skos:notation": "mej",
       "skos:prefLabel": "Melrose Children"
+    },
+    {
+      "@id": "nyplLocation:fxa03",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:fx"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Francis Martin Closed Shelf Reference",
+      "skos:notation": "fxa03",
+      "skos:prefLabel": "Francis Martin Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:hua",
@@ -30406,25 +30867,6 @@
       "skos:prefLabel": "115th Street Young Adult"
     },
     {
-      "@id": "nyplLocation:mbj0t",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mb"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Macomb's Bridge Children's Fairy Tale",
-      "skos:notation": "mbj0t",
-      "skos:prefLabel": "Macomb's Bridge Children's Fairy Tale"
-    },
-    {
       "@id": "nyplLocation:vca01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -30528,7 +30970,7 @@
       },
       "skos:altLabel": "SASB - Periodicals and Microforms Rm 119",
       "skos:notation": "mai",
-      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 100"
+      "skos:prefLabel": "Schwarzman Building - Periodicals and Microforms Room 119"
     },
     {
       "@id": "nyplLocation:kbyr",
@@ -30744,6 +31186,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -30833,6 +31276,25 @@
       "skos:altLabel": "OFFSITE - Request in Advance for use at Schwarzman Bldg -",
       "skos:notation": "rcms2",
       "skos:prefLabel": "Offsite"
+    },
+    {
+      "@id": "nyplLocation:sbyr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:sb"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "South Beach Young Adult Reference",
+      "skos:notation": "sbyr",
+      "skos:prefLabel": "South Beach Young Adult Reference"
     },
     {
       "@id": "nyplLocation:hsy01",
@@ -31690,10 +32152,10 @@
       "skos:prefLabel": "City Island Children's Non-Print Media"
     },
     {
-      "@id": "nyplLocation:ala01",
+      "@id": "nyplLocation:eaa0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:al"
+        "@id": "nyplLocation:ea"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -31704,9 +32166,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Allerton Reference",
-      "skos:notation": "ala01",
-      "skos:prefLabel": "Allerton Reference"
+      "skos:altLabel": "Eastchester Fiction",
+      "skos:notation": "eaa0f",
+      "skos:prefLabel": "Eastchester Fiction"
     },
     {
       "@id": "nyplLocation:mma33",
@@ -31729,6 +32191,28 @@
       "skos:altLabel": "Mid-Manhattan Closed Shelf Reference Third Floor",
       "skos:notation": "mma33",
       "skos:prefLabel": "Mid-Manhattan Closed Shelf Reference Third Floor"
+    },
+    {
+      "@id": "nyplLocation:mm1af",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm1af",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:wka0w",
@@ -31943,6 +32427,28 @@
       "skos:prefLabel": "58th Street Children's Fiction"
     },
     {
+      "@id": "nyplLocation:myy0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:my"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Performing Arts Circulating YA Non-Print Media",
+      "skos:notation": "myy0v",
+      "skos:prefLabel": "Performing Arts Circulating YA Non-Print Media"
+    },
+    {
       "@id": "nyplLocation:eduls",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -31979,6 +32485,25 @@
       "skos:altLabel": "Kips Bay Adult",
       "skos:notation": "kpa",
       "skos:prefLabel": "Kips Bay Adult"
+    },
+    {
+      "@id": "nyplLocation:mua0l",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mu"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Muhlenberg World Languages",
+      "skos:notation": "mua0l",
+      "skos:prefLabel": "Muhlenberg World Languages"
     },
     {
       "@id": "nyplLocation:kpj",
@@ -32019,10 +32544,10 @@
       "skos:prefLabel": "Yorkville"
     },
     {
-      "@id": "nyplLocation:pk",
+      "@id": "nyplLocation:gcj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:gc"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -32033,9 +32558,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Parkchester",
-      "skos:notation": "pk",
-      "skos:prefLabel": "Parkchester"
+      "skos:altLabel": "Grand Central Children's Non-Fiction",
+      "skos:notation": "gcj0n",
+      "skos:prefLabel": "Grand Central Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:rccf9",
@@ -32644,42 +33169,30 @@
       "skos:prefLabel": "Hudson Park Adult"
     },
     {
-      "@id": "nyplLocation:jmj0f",
+      "@id": "nyplLocation:x010",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:jm"
+        "@id": "nyplLocation:ma"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
-        "@value": "true"
+        "@value": "false"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliveryLocationType": "Research",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1000"
+      },
+      "nypl:recapCustomerCode": {
+        "@id": "http://data.nypl.org/recapCustomerCodes/OZ"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Jefferson Market Children's Fiction",
-      "skos:notation": "jmj0f",
-      "skos:prefLabel": "Jefferson Market Children's Fiction"
-    },
-    {
-      "@id": "nyplLocation:cpy0f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Clason's Point YA Fiction",
-      "skos:notation": "cpy0f",
-      "skos:prefLabel": "Clason's Point YA Fiction"
+      "skos:altLabel": "SASB no Sierra holds",
+      "skos:notation": "x010",
+      "skos:prefLabel": "SASB no Sierra holds"
     },
     {
       "@id": "nyplLocation:mhjr",
@@ -32857,36 +33370,6 @@
       "skos:altLabel": "Mulberry Street Non-Print Media",
       "skos:notation": "mla0v",
       "skos:prefLabel": "Mulberry Street Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:sc",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:sc"
-      },
-      "nypl:deliveryLocationType": "Research",
-      "nypl:locationsSlug": "schomburg",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1001"
-      },
-      "nypl:recapCustomerCode": {
-        "@id": "http://data.nypl.org/recapCustomerCodes/SR"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Schomburg Center",
-      "skos:notation": "sc",
-      "skos:prefLabel": "Schomburg Center"
     },
     {
       "@id": "nyplLocation:slr22",
@@ -33221,7 +33704,7 @@
       },
       "skos:altLabel": "SASB M2 - Map Division - Room 117",
       "skos:notation": "map92",
-      "skos:prefLabel": "Schwarzman Building M2 - Map Division - Room 117"
+      "skos:prefLabel": "Schwarzman Building M2 - Map Division Room 117"
     },
     {
       "@id": "nyplLocation:sla",
@@ -33233,6 +33716,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -33254,6 +33738,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -33947,6 +34432,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -34130,6 +34616,28 @@
       "skos:prefLabel": "Riverside Adult Learning Center"
     },
     {
+      "@id": "nyplLocation:mm4yv",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4yv",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
       "@id": "nyplLocation:mapp1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -34152,7 +34660,7 @@
       },
       "skos:altLabel": "SASB - Map Division Reference - Rm 117",
       "skos:notation": "mapp1",
-      "skos:prefLabel": "Schwarzman Building - Map Division Reference - Room 117"
+      "skos:prefLabel": "Schwarzman Building - Map Division Reference Room 117"
     },
     {
       "@id": "nyplLocation:mapp2",
@@ -34177,7 +34685,7 @@
       },
       "skos:altLabel": "SASB - Map Division - Rm 117",
       "skos:notation": "mapp2",
-      "skos:prefLabel": "Schwarzman Building - Map Division - Room 117"
+      "skos:prefLabel": "Schwarzman Building - Map Division Room 117"
     },
     {
       "@id": "nyplLocation:lba",
@@ -34313,25 +34821,6 @@
       "skos:prefLabel": "Port Richmond Children's Reference"
     },
     {
-      "@id": "nyplLocation:tgy0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Throg's Neck YA Non-Print Media",
-      "skos:notation": "tgy0v",
-      "skos:prefLabel": "Throg's Neck YA Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:pmyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -34465,10 +34954,10 @@
       "skos:prefLabel": "Fort Washington YA Non-Print Media"
     },
     {
-      "@id": "nyplLocation:dyj0v",
+      "@id": "nyplLocation:sejr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dy"
+        "@id": "nyplLocation:se"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -34479,9 +34968,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Spuyten Duyvil Children's Non-Print Media",
-      "skos:notation": "dyj0v",
-      "skos:prefLabel": "Spuyten Duyvil Children's Non-Print Media"
+      "skos:altLabel": "Seward Park Children's Reference",
+      "skos:notation": "sejr",
+      "skos:prefLabel": "Seward Park Children's Reference"
     },
     {
       "@id": "nyplLocation:whj01",
@@ -34911,25 +35400,6 @@
       "skos:prefLabel": "Schwarzman Building - Wertheim Study Room 228W - Reference"
     },
     {
-      "@id": "nyplLocation:caj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ca"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media",
-      "skos:notation": "caj0v",
-      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Children's Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:caa03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -34966,6 +35436,25 @@
       "skos:altLabel": "Terence Cardinal Cooke-Cathedral Reference",
       "skos:notation": "caa01",
       "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Reference"
+    },
+    {
+      "@id": "nyplLocation:nsyr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ns"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "96th Street Young Adult Reference",
+      "skos:notation": "nsyr",
+      "skos:prefLabel": "96th Street Young Adult Reference"
     },
     {
       "@id": "nyplLocation:vcar",
@@ -35069,10 +35558,10 @@
       "skos:prefLabel": "West Farms Children's World Languages"
     },
     {
-      "@id": "nyplLocation:fxa03",
+      "@id": "nyplLocation:whj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fx"
+        "@id": "nyplLocation:wh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -35083,9 +35572,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Francis Martin Closed Shelf Reference",
-      "skos:notation": "fxa03",
-      "skos:prefLabel": "Francis Martin Closed Shelf Reference"
+      "skos:altLabel": "Washington Heights Children's Easy Book",
+      "skos:notation": "whj0a",
+      "skos:prefLabel": "Washington Heights Children's Easy Book"
     },
     {
       "@id": "nyplLocation:rda",
@@ -35664,10 +36153,10 @@
       "skos:prefLabel": "Dongan Hills Children"
     },
     {
-      "@id": "nyplLocation:rdy0f",
+      "@id": "nyplLocation:wka",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
+        "@id": "nyplLocation:wk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -35678,9 +36167,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Riverdale YA Fiction",
-      "skos:notation": "rdy0f",
-      "skos:prefLabel": "Riverdale YA Fiction"
+      "skos:altLabel": "Wakefield Adult",
+      "skos:notation": "wka",
+      "skos:prefLabel": "Wakefield Adult"
     },
     {
       "@id": "nyplLocation:dha",
@@ -35702,10 +36191,10 @@
       "skos:prefLabel": "Dongan Hills Adult"
     },
     {
-      "@id": "nyplLocation:bta0n",
+      "@id": "nyplLocation:dhy0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:bt"
+        "@id": "nyplLocation:dh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -35716,9 +36205,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Battery Park Non-Fiction",
-      "skos:notation": "bta0n",
-      "skos:prefLabel": "Battery Park Non-Fiction"
+      "skos:altLabel": "Dongan Hills YA World Languages",
+      "skos:notation": "dhy0l",
+      "skos:prefLabel": "Dongan Hills YA World Languages"
     },
     {
       "@id": "nyplLocation:wkj",
@@ -35740,10 +36229,10 @@
       "skos:prefLabel": "Wakefield Children"
     },
     {
-      "@id": "nyplLocation:kpy0n",
+      "@id": "nyplLocation:rdy0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:kp"
+        "@id": "nyplLocation:rd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -35754,9 +36243,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Kips Bay YA Non-Fiction",
-      "skos:notation": "kpy0n",
-      "skos:prefLabel": "Kips Bay YA Non-Fiction"
+      "skos:altLabel": "Riverdale YA World Languages",
+      "skos:notation": "rdy0l",
+      "skos:prefLabel": "Riverdale YA World Languages"
     },
     {
       "@id": "nyplLocation:rdy0n",
@@ -35892,10 +36381,10 @@
       "skos:prefLabel": "125th Street Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:bta0f",
+      "@id": "nyplLocation:cpa03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:bt"
+        "@id": "nyplLocation:cp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -35906,9 +36395,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Battery Park Fiction",
-      "skos:notation": "bta0f",
-      "skos:prefLabel": "Battery Park Fiction"
+      "skos:altLabel": "Clason's Point Closed Shelf Reference",
+      "skos:notation": "cpa03",
+      "skos:prefLabel": "Clason's Point Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:sazzz",
@@ -36034,6 +36523,25 @@
       "skos:prefLabel": "Woodstock Young Adult Reference"
     },
     {
+      "@id": "nyplLocation:kby01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:kb"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Kingsbridge YA Reference",
+      "skos:notation": "kby01",
+      "skos:prefLabel": "Kingsbridge YA Reference"
+    },
+    {
       "@id": "nyplLocation:bra0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -36051,25 +36559,6 @@
       "skos:altLabel": "George Bruce Non-Print Media",
       "skos:notation": "bra0v",
       "skos:prefLabel": "George Bruce Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:ssj0a",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ss"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "67th Street Children's Easy Book",
-      "skos:notation": "ssj0a",
-      "skos:prefLabel": "67th Street Children's Easy Book"
     },
     {
       "@id": "nyplLocation:ciy01",
@@ -36132,10 +36621,10 @@
       "skos:prefLabel": "Countee Cullen Closed Shelf Reference"
     },
     {
-      "@id": "nyplLocation:cayr",
+      "@id": "nyplLocation:ssj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ca"
+        "@id": "nyplLocation:ss"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -36146,9 +36635,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference",
-      "skos:notation": "cayr",
-      "skos:prefLabel": "Terence Cardinal Cooke-Cathedral Young Adult Reference"
+      "skos:altLabel": "67th Street Children's Fiction",
+      "skos:notation": "ssj0f",
+      "skos:prefLabel": "67th Street Children's Fiction"
     },
     {
       "@id": "nyplLocation:hta01",
@@ -36189,10 +36678,10 @@
       "skos:prefLabel": "Parkchester Young Adult"
     },
     {
-      "@id": "nyplLocation:sezzz",
+      "@id": "nyplLocation:pka",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:pk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -36203,9 +36692,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Seward Park (error code)",
-      "skos:notation": "sezzz",
-      "skos:prefLabel": "Seward Park"
+      "skos:altLabel": "Parkchester Adult",
+      "skos:notation": "pka",
+      "skos:prefLabel": "Parkchester Adult"
     },
     {
       "@id": "nyplLocation:ma0p",
@@ -36810,10 +37299,10 @@
       "skos:prefLabel": "St. Agnes Children's Reference"
     },
     {
-      "@id": "nyplLocation:csy0f",
+      "@id": "nyplLocation:eaj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cs"
+        "@id": "nyplLocation:ea"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -36824,9 +37313,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Columbus YA Fiction",
-      "skos:notation": "csy0f",
-      "skos:prefLabel": "Columbus YA Fiction"
+      "skos:altLabel": "Eastchester Children's Picture Book",
+      "skos:notation": "eaj0i",
+      "skos:prefLabel": "Eastchester Children's Picture Book"
     },
     {
       "@id": "nyplLocation:hky0f",
@@ -36846,44 +37335,6 @@
       "skos:altLabel": "Huguenot Park YA Fiction",
       "skos:notation": "hky0f",
       "skos:prefLabel": "Huguenot Park YA Fiction"
-    },
-    {
-      "@id": "nyplLocation:hda0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:hd"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "125th Street Non-Print Media",
-      "skos:notation": "hda0v",
-      "skos:prefLabel": "125th Street Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:sv",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sv"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Soundview",
-      "skos:notation": "sv",
-      "skos:prefLabel": "Soundview"
     },
     {
       "@id": "nyplLocation:hfyr",
@@ -36965,7 +37416,7 @@
       },
       "skos:altLabel": "SASB - Map Division - Desk - Rm 117",
       "skos:notation": "mapp3",
-      "skos:prefLabel": "Schwarzman Building - Map Division - Desk - Room 117"
+      "skos:prefLabel": "Schwarzman Building - Map Division Desk Room 117"
     },
     {
       "@id": "nyplLocation:htj01",
@@ -37012,10 +37463,10 @@
       "skos:prefLabel": "Science, Industry and Business Library (SIBL) - B. Altman Desk"
     },
     {
-      "@id": "nyplLocation:sdj01",
+      "@id": "nyplLocation:woj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sd"
+        "@id": "nyplLocation:wo"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -37026,9 +37477,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Sedgwick Children's Reference",
-      "skos:notation": "sdj01",
-      "skos:prefLabel": "Sedgwick Children's Reference"
+      "skos:altLabel": "Woodstock Children's Holiday Book",
+      "skos:notation": "woj0h",
+      "skos:prefLabel": "Woodstock Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:woj0i",
@@ -37430,6 +37881,25 @@
       "skos:prefLabel": "Van Nest"
     },
     {
+      "@id": "nyplLocation:wfjr",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wf"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "West Farms Children's Reference",
+      "skos:notation": "wfjr",
+      "skos:prefLabel": "West Farms Children's Reference"
+    },
+    {
       "@id": "nyplLocation:agy0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -37580,25 +38050,6 @@
       "skos:altLabel": "Aguilar YA Fiction",
       "skos:notation": "agy0f",
       "skos:prefLabel": "Aguilar YA Fiction"
-    },
-    {
-      "@id": "nyplLocation:fey",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "58th Street Young Adult",
-      "skos:notation": "fey",
-      "skos:prefLabel": "58th Street Young Adult"
     },
     {
       "@id": "nyplLocation:hsa0v",
@@ -37884,6 +38335,25 @@
       "skos:altLabel": "Tremont Reference",
       "skos:notation": "tma01",
       "skos:prefLabel": "Tremont Reference"
+    },
+    {
+      "@id": "nyplLocation:bl",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:bl"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Bloomingdale",
+      "skos:notation": "bl",
+      "skos:prefLabel": "Bloomingdale"
     },
     {
       "@id": "nyplLocation:tma03",
@@ -38196,10 +38666,10 @@
       "skos:prefLabel": "Bloomingdale Adult Reference"
     },
     {
-      "@id": "nyplLocation:cia0l",
+      "@id": "nyplLocation:inj0h",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ci"
+        "@id": "nyplLocation:in"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -38210,9 +38680,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "City Island World Languages",
-      "skos:notation": "cia0l",
-      "skos:prefLabel": "City Island World Languages"
+      "skos:altLabel": "Inwood Children's Holiday Book",
+      "skos:notation": "inj0h",
+      "skos:prefLabel": "Inwood Children's Holiday Book"
     },
     {
       "@id": "nyplLocation:bea03",
@@ -38262,6 +38732,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -38272,6 +38743,28 @@
       "skos:altLabel": "SIBL - Reference",
       "skos:notation": "sla01",
       "skos:prefLabel": "Science, Industry and Business Library (SIBL) - Reference"
+    },
+    {
+      "@id": "nyplLocation:mm3yv",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm3yv",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:baj",
@@ -38470,29 +38963,10 @@
       "skos:prefLabel": "Temporary Storage"
     },
     {
-      "@id": "nyplLocation:mry0v",
+      "@id": "nyplLocation:sla0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mr"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Morrisania YA Non-Print Media",
-      "skos:notation": "mry0v",
-      "skos:prefLabel": "Morrisania YA Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:mma2f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:mm"
+        "@id": "nyplLocation:sl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -38500,15 +38974,34 @@
       },
       "nypl:collectionType": "Branch",
       "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1500"
+        "@id": "http://data.nypl.org/orgs/1125"
       },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mid-Manhattan Fiction Second Floor",
-      "skos:notation": "mma2f",
-      "skos:prefLabel": "Mid-Manhattan Fiction Second Floor"
+      "skos:altLabel": "SIBL - Non-Fiction",
+      "skos:notation": "sla0n",
+      "skos:prefLabel": "Science, Industry and Business Library (SIBL) - Non-Fiction"
+    },
+    {
+      "@id": "nyplLocation:rty0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:rt"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Richmondtown YA Non-Print Media",
+      "skos:notation": "rty0v",
+      "skos:prefLabel": "Richmondtown YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:bea0n",
@@ -38558,6 +39051,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -38570,10 +39064,10 @@
       "skos:prefLabel": "Science, Industry and Business Library (SIBL) - Fiction"
     },
     {
-      "@id": "nyplLocation:tgar",
+      "@id": "nyplLocation:hda0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tg"
+        "@id": "nyplLocation:hd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -38584,9 +39078,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Throg's Neck Adult Reference",
-      "skos:notation": "tgar",
-      "skos:prefLabel": "Throg's Neck Adult Reference"
+      "skos:altLabel": "125th Street Non-Print Media",
+      "skos:notation": "hda0v",
+      "skos:prefLabel": "125th Street Non-Print Media"
     },
     {
       "@id": "nyplLocation:bea0v",
@@ -38693,6 +39187,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -38705,10 +39200,10 @@
       "skos:prefLabel": "Science, Industry and Business Library (SIBL) - Non-Print Media"
     },
     {
-      "@id": "nyplLocation:rty0n",
+      "@id": "nyplLocation:mhj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
+        "@id": "nyplLocation:mh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -38719,9 +39214,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Richmondtown YA Non-Fiction",
-      "skos:notation": "rty0n",
-      "skos:prefLabel": "Richmondtown YA Non-Fiction"
+      "skos:altLabel": "Mott Haven Children's Non-Fiction",
+      "skos:notation": "mhj0n",
+      "skos:prefLabel": "Mott Haven Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:fezzz",
@@ -39015,10 +39510,10 @@
       "skos:prefLabel": "Stapleton YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:hkj0i",
+      "@id": "nyplLocation:muj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hk"
+        "@id": "nyplLocation:mu"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -39029,9 +39524,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Huguenot Park Children's Picture Book",
-      "skos:notation": "hkj0i",
-      "skos:prefLabel": "Huguenot Park Children's Picture Book"
+      "skos:altLabel": "Muhlenberg Children's Non-Print Media",
+      "skos:notation": "muj0v",
+      "skos:prefLabel": "Muhlenberg Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:macc2",
@@ -39076,6 +39571,25 @@
       "skos:altLabel": "Stapleton YA Fiction",
       "skos:notation": "sty0f",
       "skos:prefLabel": "Stapleton YA Fiction"
+    },
+    {
+      "@id": "nyplLocation:hfy",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:hf"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Hamilton Fish Park Young Adult",
+      "skos:notation": "hfy",
+      "skos:prefLabel": "Hamilton Fish Park Young Adult"
     },
     {
       "@id": "nyplLocation:fwa",
@@ -39154,10 +39668,10 @@
       "skos:prefLabel": "Belmont"
     },
     {
-      "@id": "nyplLocation:hbj0v",
+      "@id": "nyplLocation:mha0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hb"
+        "@id": "nyplLocation:mh"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -39168,9 +39682,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "High Bridge Children's Non-Print Media",
-      "skos:notation": "hbj0v",
-      "skos:prefLabel": "High Bridge Children's Non-Print Media"
+      "skos:altLabel": "Mott Haven Non-Print Media",
+      "skos:notation": "mha0v",
+      "skos:prefLabel": "Mott Haven Non-Print Media"
     },
     {
       "@id": "nyplLocation:fwy",
@@ -39287,31 +39801,6 @@
       "skos:prefLabel": "Countee Cullen Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:mym42",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Research",
-      "nypl:deliverableTo": {
-        "@id": "nyplLocation:myr"
-      },
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1002"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "OFFSITE Rose - Request in advance for use at Performing Arts",
-      "skos:notation": "mym42",
-      "skos:prefLabel": "Offsite Rose - Performing Arts"
-    },
-    {
       "@id": "nyplLocation:htj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -39329,25 +39818,6 @@
       "skos:altLabel": "Countee Cullen Children's Easy Book",
       "skos:notation": "htj0a",
       "skos:prefLabel": "Countee Cullen Children's Easy Book"
-    },
-    {
-      "@id": "nyplLocation:saa0f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:sa"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "St. Agnes Fiction",
-      "skos:notation": "saa0f",
-      "skos:prefLabel": "St. Agnes Fiction"
     },
     {
       "@id": "nyplLocation:htj0f",
@@ -39483,6 +39953,25 @@
       "skos:prefLabel": "Countee Cullen Children's Non-Print Media"
     },
     {
+      "@id": "nyplLocation:clzzz",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:cl"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Morningside Heights (error code)",
+      "skos:notation": "clzzz",
+      "skos:prefLabel": "Morningside Heights"
+    },
+    {
       "@id": "nyplLocation:iny01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -39538,25 +40027,6 @@
       "skos:altLabel": "Morris Park Children's Reference",
       "skos:notation": "mpj01",
       "skos:prefLabel": "Morris Park Children's Reference"
-    },
-    {
-      "@id": "nyplLocation:epj0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ep"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Epiphany Children's World Languages",
-      "skos:notation": "epj0l",
-      "skos:prefLabel": "Epiphany Children's World Languages"
     },
     {
       "@id": "nyplLocation:wlj0y",
@@ -39619,10 +40089,10 @@
       "skos:prefLabel": "Stapleton Children's Reference"
     },
     {
-      "@id": "nyplLocation:mha0f",
+      "@id": "nyplLocation:wlj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mh"
+        "@id": "nyplLocation:wl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -39633,9 +40103,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mott Haven Fiction",
-      "skos:notation": "mha0f",
-      "skos:prefLabel": "Mott Haven Fiction"
+      "skos:altLabel": "Woodlawn Heights Children's Non-Print Media",
+      "skos:notation": "wlj0v",
+      "skos:prefLabel": "Woodlawn Heights Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:wlj0t",
@@ -40027,25 +40497,6 @@
       "skos:prefLabel": "Morris Park Children's Non-Fiction"
     },
     {
-      "@id": "nyplLocation:styr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:st"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Stapleton Young Adult Reference",
-      "skos:notation": "styr",
-      "skos:prefLabel": "Stapleton Young Adult Reference"
-    },
-    {
       "@id": "nyplLocation:dyzzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -40274,10 +40725,10 @@
       "skos:prefLabel": "St. George Children's World Languages"
     },
     {
-      "@id": "nyplLocation:wfjr",
+      "@id": "nyplLocation:epj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wf"
+        "@id": "nyplLocation:ep"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -40288,9 +40739,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West Farms Children's Reference",
-      "skos:notation": "wfjr",
-      "skos:prefLabel": "West Farms Children's Reference"
+      "skos:altLabel": "Epiphany Children's World Languages",
+      "skos:notation": "epj0l",
+      "skos:prefLabel": "Epiphany Children's World Languages"
     },
     {
       "@id": "nyplLocation:sgj0h",
@@ -40350,10 +40801,10 @@
       "skos:prefLabel": "St. George Children's Fiction"
     },
     {
-      "@id": "nyplLocation:pra0f",
+      "@id": "nyplLocation:wta03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pr"
+        "@id": "nyplLocation:wt"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -40364,9 +40815,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Port Richmond Fiction",
-      "skos:notation": "pra0f",
-      "skos:prefLabel": "Port Richmond Fiction"
+      "skos:altLabel": "Westchester Square Closed Shelf Reference",
+      "skos:notation": "wta03",
+      "skos:prefLabel": "Westchester Square Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:wlj01",
@@ -40483,10 +40934,10 @@
       "skos:prefLabel": "St. George Children's Young Reader"
     },
     {
-      "@id": "nyplLocation:sgj0v",
+      "@id": "nyplLocation:fea",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:fe"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -40497,15 +40948,15 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "St. George Children's Non-Print Media",
-      "skos:notation": "sgj0v",
-      "skos:prefLabel": "St. George Children's Non-Print Media"
+      "skos:altLabel": "58th Street Adult",
+      "skos:notation": "fea",
+      "skos:prefLabel": "58th Street Adult"
     },
     {
-      "@id": "nyplLocation:rdj0l",
+      "@id": "nyplLocation:prj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
+        "@id": "nyplLocation:pr"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -40516,9 +40967,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Riverdale Children's World Languages",
-      "skos:notation": "rdj0l",
-      "skos:prefLabel": "Riverdale Children's World Languages"
+      "skos:altLabel": "Port Richmond Children's Non-Print Media",
+      "skos:notation": "prj0v",
+      "skos:prefLabel": "Port Richmond Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:sgj0t",
@@ -40719,10 +41170,10 @@
       "skos:prefLabel": "Google Books Project"
     },
     {
-      "@id": "nyplLocation:nsy0f",
+      "@id": "nyplLocation:ina",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ns"
+        "@id": "nyplLocation:in"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -40733,9 +41184,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "96th Street YA Fiction",
-      "skos:notation": "nsy0f",
-      "skos:prefLabel": "96th Street YA Fiction"
+      "skos:altLabel": "Inwood Adult",
+      "skos:notation": "ina",
+      "skos:prefLabel": "Inwood Adult"
     },
     {
       "@id": "nyplLocation:dyy0l",
@@ -40937,25 +41388,6 @@
       "skos:prefLabel": "Mid-Manhattan Children's Reference"
     },
     {
-      "@id": "nyplLocation:csj0v",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:cs"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Columbus Children's Non-Print Media",
-      "skos:notation": "csj0v",
-      "skos:prefLabel": "Columbus Children's Non-Print Media"
-    },
-    {
       "@id": "nyplLocation:hpa0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -40995,6 +41427,28 @@
       "skos:altLabel": "Performing Arts Song Index Reference Score",
       "skos:notation": "myas1",
       "skos:prefLabel": "Performing Arts Song Index Reference Score"
+    },
+    {
+      "@id": "nyplLocation:mm3al",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm3al",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:hpa0n",
@@ -41090,6 +41544,28 @@
       "skos:altLabel": "Hudson Park Non-Print Media",
       "skos:notation": "hpa0v",
       "skos:prefLabel": "Hudson Park Non-Print Media"
+    },
+    {
+      "@id": "nyplLocation:mm3av",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm3av",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:fxy0l",
@@ -41339,10 +41815,10 @@
       "skos:prefLabel": "Fort Washington Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:whj0a",
+      "@id": "nyplLocation:fwj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wh"
+        "@id": "nyplLocation:fw"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -41353,9 +41829,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Washington Heights Children's Easy Book",
-      "skos:notation": "whj0a",
-      "skos:prefLabel": "Washington Heights Children's Easy Book"
+      "skos:altLabel": "Fort Washington Children's Non-Fiction",
+      "skos:notation": "fwj0n",
+      "skos:prefLabel": "Fort Washington Children's Non-Fiction"
     },
     {
       "@id": "nyplLocation:fwj0l",
@@ -41434,10 +41910,10 @@
       "skos:prefLabel": "53rd Street Children's World Languages"
     },
     {
-      "@id": "nyplLocation:wfj0n",
+      "@id": "nyplLocation:cpj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wf"
+        "@id": "nyplLocation:cp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -41448,9 +41924,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West Farms Children's Non-Fiction",
-      "skos:notation": "wfj0n",
-      "skos:prefLabel": "West Farms Children's Non-Fiction"
+      "skos:altLabel": "Clason's Point Children's World Languages",
+      "skos:notation": "cpj0l",
+      "skos:prefLabel": "Clason's Point Children's World Languages"
     },
     {
       "@id": "nyplLocation:fwj0v",
@@ -41966,10 +42442,10 @@
       "skos:prefLabel": "Tompkins Square Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:clj0h",
+      "@id": "nyplLocation:svj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cl"
+        "@id": "nyplLocation:sv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -41980,9 +42456,28 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Morningside Heights Children's Holiday Book",
-      "skos:notation": "clj0h",
-      "skos:prefLabel": "Morningside Heights Children's Holiday Book"
+      "skos:altLabel": "Soundview Children",
+      "skos:notation": "svj",
+      "skos:prefLabel": "Soundview Children"
+    },
+    {
+      "@id": "nyplLocation:ftzzz",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ft"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "53rd Street (error code)",
+      "skos:notation": "ftzzz",
+      "skos:prefLabel": "53rd Street"
     },
     {
       "@id": "nyplLocation:tsj0l",
@@ -42078,6 +42573,28 @@
       "skos:altLabel": "Westchester Square Young Adult Reference",
       "skos:notation": "wtyr",
       "skos:prefLabel": "Westchester Square Young Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:mm4yl",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4yl",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:mac82",
@@ -42592,10 +43109,10 @@
       "skos:prefLabel": "Mott Haven Reference"
     },
     {
-      "@id": "nyplLocation:hty0v",
+      "@id": "nyplLocation:cpj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ht"
+        "@id": "nyplLocation:cp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -42606,9 +43123,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Countee Cullen YA Non-Print Media",
-      "skos:notation": "hty0v",
-      "skos:prefLabel": "Countee Cullen YA Non-Print Media"
+      "skos:altLabel": "Clason's Point Children's Young Reader",
+      "skos:notation": "cpj0y",
+      "skos:prefLabel": "Clason's Point Children's Young Reader"
     },
     {
       "@id": "nyplLocation:tsj01",
@@ -42706,10 +43223,10 @@
       "skos:prefLabel": "Woodlawn Heights Young Adult Reference"
     },
     {
-      "@id": "nyplLocation:mua03",
+      "@id": "nyplLocation:pky0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mu"
+        "@id": "nyplLocation:pk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -42720,9 +43237,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Muhlenberg Closed Shelf Reference",
-      "skos:notation": "mua03",
-      "skos:prefLabel": "Muhlenberg Closed Shelf Reference"
+      "skos:altLabel": "Parkchester YA World Languages",
+      "skos:notation": "pky0l",
+      "skos:prefLabel": "Parkchester YA World Languages"
     },
     {
       "@id": "nyplLocation:hty0f",
@@ -43386,10 +43903,10 @@
       "skos:prefLabel": "High Bridge Young Adult"
     },
     {
-      "@id": "nyplLocation:sea0w",
+      "@id": "nyplLocation:sbj0i",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:sb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -43400,9 +43917,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Seward Park Center for Reading & Writing",
-      "skos:notation": "sea0w",
-      "skos:prefLabel": "Seward Park Center for Reading & Writing"
+      "skos:altLabel": "South Beach Children's Picture Book",
+      "skos:notation": "sbj0i",
+      "skos:prefLabel": "South Beach Children's Picture Book"
     },
     {
       "@id": "nyplLocation:sea0v",
@@ -43632,10 +44149,10 @@
       "skos:prefLabel": "Tremont YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:hfy0f",
+      "@id": "nyplLocation:fty0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hf"
+        "@id": "nyplLocation:ft"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -43646,9 +44163,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Hamilton Fish Park YA Fiction",
-      "skos:notation": "hfy0f",
-      "skos:prefLabel": "Hamilton Fish Park YA Fiction"
+      "skos:altLabel": "53rd Street YA Non-Print Media",
+      "skos:notation": "fty0v",
+      "skos:prefLabel": "53rd Street YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:tsy0f",
@@ -43991,25 +44508,6 @@
       "skos:altLabel": "Van Cortlandt Children's Non-Fiction",
       "skos:notation": "vcj0n",
       "skos:prefLabel": "Van Cortlandt Children's Non-Fiction"
-    },
-    {
-      "@id": "nyplLocation:ndj0f",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:nd"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "New Dorp Children's Fiction",
-      "skos:notation": "ndj0f",
-      "skos:prefLabel": "New Dorp Children's Fiction"
     },
     {
       "@id": "nyplLocation:vcj0l",
@@ -44392,10 +44890,10 @@
       "skos:prefLabel": "Morrisania Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:sejr",
+      "@id": "nyplLocation:dyj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:dy"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -44406,9 +44904,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Seward Park Children's Reference",
-      "skos:notation": "sejr",
-      "skos:prefLabel": "Seward Park Children's Reference"
+      "skos:altLabel": "Spuyten Duyvil Children's Non-Print Media",
+      "skos:notation": "dyj0v",
+      "skos:prefLabel": "Spuyten Duyvil Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:dyj0t",
@@ -44542,6 +45040,25 @@
       "skos:altLabel": "Epiphany (error code)",
       "skos:notation": "epzzz",
       "skos:prefLabel": "Epiphany"
+    },
+    {
+      "@id": "nyplLocation:tsy0l",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ts"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Tompkins Square YA World Languages",
+      "skos:notation": "tsy0l",
+      "skos:prefLabel": "Tompkins Square YA World Languages"
     },
     {
       "@id": "nyplLocation:dhzzz",
@@ -44737,25 +45254,6 @@
       "skos:prefLabel": "High Bridge YA Non-Print Media"
     },
     {
-      "@id": "nyplLocation:rtj0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:rt"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Richmondtown Children's Non-Fiction",
-      "skos:notation": "rtj0n",
-      "skos:prefLabel": "Richmondtown Children's Non-Fiction"
-    },
-    {
       "@id": "nyplLocation:dyj01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -44870,10 +45368,10 @@
       "skos:prefLabel": "City Island Non-Print Media"
     },
     {
-      "@id": "nyplLocation:wka",
+      "@id": "nyplLocation:rdy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wk"
+        "@id": "nyplLocation:rd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -44884,9 +45382,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Wakefield Adult",
-      "skos:notation": "wka",
-      "skos:prefLabel": "Wakefield Adult"
+      "skos:altLabel": "Riverdale YA Fiction",
+      "skos:notation": "rdy0f",
+      "skos:prefLabel": "Riverdale YA Fiction"
     },
     {
       "@id": "nyplLocation:inj0v",
@@ -44965,10 +45463,10 @@
       "skos:prefLabel": "Inwood Children's Picture Book"
     },
     {
-      "@id": "nyplLocation:inj0h",
+      "@id": "nyplLocation:cia0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:in"
+        "@id": "nyplLocation:ci"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -44979,9 +45477,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Inwood Children's Holiday Book",
-      "skos:notation": "inj0h",
-      "skos:prefLabel": "Inwood Children's Holiday Book"
+      "skos:altLabel": "City Island World Languages",
+      "skos:notation": "cia0l",
+      "skos:prefLabel": "City Island World Languages"
     },
     {
       "@id": "nyplLocation:inj0n",
@@ -45120,25 +45618,6 @@
       "skos:prefLabel": "Offsite"
     },
     {
-      "@id": "nyplLocation:rdy0l",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:rd"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Riverdale YA World Languages",
-      "skos:notation": "rdy0l",
-      "skos:prefLabel": "Riverdale YA World Languages"
-    },
-    {
       "@id": "nyplLocation:mabb1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -45211,7 +45690,7 @@
       },
       "skos:altLabel": "SASB - Art - Desk Rm 300",
       "skos:notation": "mabb3",
-      "skos:prefLabel": "Schwarzman Building - Art & Architecture - Desk Room 300"
+      "skos:prefLabel": "Schwarzman Building - Art & Architecture Desk Room 300"
     },
     {
       "@id": "nyplLocation:magh1",
@@ -45492,25 +45971,6 @@
       "skos:altLabel": "67th Street YA Fiction",
       "skos:notation": "ssy0f",
       "skos:prefLabel": "67th Street YA Fiction"
-    },
-    {
-      "@id": "nyplLocation:tha01",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:th"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Todt Hill-Westerleigh Reference",
-      "skos:notation": "tha01",
-      "skos:prefLabel": "Todt Hill-Westerleigh Reference"
     },
     {
       "@id": "nyplLocation:epy0f",
@@ -46247,10 +46707,10 @@
       "skos:prefLabel": "Hamilton Fish Park Fiction"
     },
     {
-      "@id": "nyplLocation:nbj0l",
+      "@id": "nyplLocation:ndj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:nb"
+        "@id": "nyplLocation:nd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -46261,9 +46721,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "West New Brighton Children's World Languages",
-      "skos:notation": "nbj0l",
-      "skos:prefLabel": "West New Brighton Children's World Languages"
+      "skos:altLabel": "New Dorp Children's Fiction",
+      "skos:notation": "ndj0f",
+      "skos:prefLabel": "New Dorp Children's Fiction"
     },
     {
       "@id": "nyplLocation:stj0a",
@@ -46532,6 +46992,31 @@
       "skos:prefLabel": "Stapleton Children's Young Reader"
     },
     {
+      "@id": "nyplLocation:mym28",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:my"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1123"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Performing Arts Research Collections - Music",
+      "skos:notation": "mym28",
+      "skos:prefLabel": "Performing Arts Research Collections - Music"
+    },
+    {
       "@id": "nyplLocation:maff1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -46579,7 +47064,7 @@
       },
       "skos:altLabel": "SASB - Dorot Jewish Division - Desk Rm 111",
       "skos:notation": "maff3",
-      "skos:prefLabel": "Schwarzman Building - Dorot Jewish Division - Desk Room 111"
+      "skos:prefLabel": "Schwarzman Building - Dorot Jewish Division Desk Room 111"
     },
     {
       "@id": "nyplLocation:wljr",
@@ -46601,10 +47086,10 @@
       "skos:prefLabel": "Woodlawn Heights Children's Reference"
     },
     {
-      "@id": "nyplLocation:sga0w",
+      "@id": "nyplLocation:ndj0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sg"
+        "@id": "nyplLocation:nd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -46615,9 +47100,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "St. George Center for Reading & Writing",
-      "skos:notation": "sga0w",
-      "skos:prefLabel": "St. George Center for Reading & Writing"
+      "skos:altLabel": "New Dorp Children's World Languages",
+      "skos:notation": "ndj0l",
+      "skos:prefLabel": "New Dorp Children's World Languages"
     },
     {
       "@id": "nyplLocation:ssy0n",
@@ -46677,6 +47162,25 @@
       "skos:prefLabel": "Spuyten Duyvil Non-Print Media"
     },
     {
+      "@id": "nyplLocation:cpy0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:cp"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Clason's Point YA Fiction",
+      "skos:notation": "cpy0f",
+      "skos:prefLabel": "Clason's Point YA Fiction"
+    },
+    {
       "@id": "nyplLocation:tsyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -46708,7 +47212,22 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
           "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:mab"
@@ -46717,25 +47236,10 @@
           "@id": "nyplLocation:malc"
         },
         {
-          "@id": "nyplLocation:maln"
+          "@id": "nyplLocation:maf"
         },
         {
           "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:map"
-        },
-        {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:maf"
         }
       ],
       "nypl:owner": {
@@ -47035,6 +47539,28 @@
       "skos:prefLabel": "New Dorp World Languages"
     },
     {
+      "@id": "nyplLocation:mma1f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Fiction First Floor",
+      "skos:notation": "mma1f",
+      "skos:prefLabel": "Mid-Manhattan Fiction First Floor"
+    },
+    {
       "@id": "nyplLocation:bcyr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -47187,10 +47713,10 @@
       "skos:prefLabel": "Port Richmond Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:hfy",
+      "@id": "nyplLocation:hla0l",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hf"
+        "@id": "nyplLocation:hl"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -47201,9 +47727,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Hamilton Fish Park Young Adult",
-      "skos:notation": "hfy",
-      "skos:prefLabel": "Hamilton Fish Park Young Adult"
+      "skos:altLabel": "Harlem World Languages",
+      "skos:notation": "hla0l",
+      "skos:prefLabel": "Harlem World Languages"
     },
     {
       "@id": "nyplLocation:nbj0v",
@@ -47449,34 +47975,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:map"
-        },
-        {
           "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:maf"
         },
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:mai"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:maln"
         }
       ],
       "nypl:owner": {
@@ -48023,10 +48549,10 @@
       "skos:prefLabel": "Kips Bay Reference"
     },
     {
-      "@id": "nyplLocation:hsyr",
+      "@id": "nyplLocation:kpa03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hs"
+        "@id": "nyplLocation:kp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -48037,9 +48563,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Hunt's Point Young Adult Reference",
-      "skos:notation": "hsyr",
-      "skos:prefLabel": "Hunt's Point Young Adult Reference"
+      "skos:altLabel": "Kips Bay Closed Shelf Reference",
+      "skos:notation": "kpa03",
+      "skos:prefLabel": "Kips Bay Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:hpy0v",
@@ -48415,10 +48941,10 @@
       "skos:prefLabel": "Mariner's Harbor Non-Print Media"
     },
     {
-      "@id": "nyplLocation:fey0n",
+      "@id": "nyplLocation:ndy01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:nd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -48429,9 +48955,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "58th Street YA Non-Fiction",
-      "skos:notation": "fey0n",
-      "skos:prefLabel": "58th Street YA Non-Fiction"
+      "skos:altLabel": "New Dorp YA Reference",
+      "skos:notation": "ndy01",
+      "skos:prefLabel": "New Dorp YA Reference"
     },
     {
       "@id": "nyplLocation:fey0l",
@@ -48462,6 +48988,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Research",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1000"
       },
@@ -48643,25 +49170,6 @@
       "skos:altLabel": "Kips Bay Non-Print Media",
       "skos:notation": "kpa0v",
       "skos:prefLabel": "Kips Bay Non-Print Media"
-    },
-    {
-      "@id": "nyplLocation:yvjr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:yv"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Yorkville Children's Reference",
-      "skos:notation": "yvjr",
-      "skos:prefLabel": "Yorkville Children's Reference"
     },
     {
       "@id": "nyplLocation:agj0v",
@@ -49010,34 +49518,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:mala"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
           "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
-          "@id": "nyplLocation:mai"
         },
         {
           "@id": "nyplLocation:mal"
         },
         {
-          "@id": "nyplLocation:mab"
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:maf"
         },
         {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:malc"
         }
       ],
       "nypl:owner": {
@@ -49049,7 +49557,7 @@
       },
       "skos:altLabel": "SASB M2 - General Research - Room 315",
       "skos:notation": "maj92",
-      "skos:prefLabel": "Schwarzman Building M2 - General Research - Room 315"
+      "skos:prefLabel": "Schwarzman Building M2 - General Research Room 315"
     },
     {
       "@id": "nyplLocation:mea01",
@@ -49128,23 +49636,26 @@
       "skos:prefLabel": "Yorkville Non-Print Media"
     },
     {
-      "@id": "nyplLocation:lsbx2",
+      "@id": "nyplLocation:mma",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ls"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Research",
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Library Services Center - Cataloging - Research Storage",
-      "skos:notation": "lsbx2",
-      "skos:prefLabel": "Library Services Center - Cataloging - Research Storage"
+      "skos:altLabel": "Mid-Manhattan Adult",
+      "skos:notation": "mma",
+      "skos:prefLabel": "Mid-Manhattan Adult"
     },
     {
       "@id": "nyplLocation:yva0f",
@@ -49190,25 +49701,6 @@
       "skos:altLabel": "SASB - Barcoding Project",
       "skos:notation": "ma0b",
       "skos:prefLabel": "Schwarzman Building - Barcoding Project"
-    },
-    {
-      "@id": "nyplLocation:alj0y",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:al"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Allerton Children's Young Reader",
-      "skos:notation": "alj0y",
-      "skos:prefLabel": "Allerton Children's Young Reader"
     },
     {
       "@id": "nyplLocation:btar",
@@ -49534,6 +50026,31 @@
       "skos:prefLabel": "67th Street Children's Reference"
     },
     {
+      "@id": "nyplLocation:mau",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ma"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:mau"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1112"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "SASB - Print Collection Rm 308",
+      "skos:notation": "mau",
+      "skos:prefLabel": "Schwarzman Building - Print Collection Room 308"
+    },
+    {
       "@id": "nyplLocation:yva01",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -49639,15 +50156,15 @@
         "@value": "true"
       },
       "nypl:collectionType": [
-        "Branch",
-        "Research"
+        "Research",
+        "Branch"
       ],
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myrfv"
       },
       "nypl:deliveryLocationType": [
-        "Branch",
-        "Research"
+        "Research",
+        "Branch"
       ],
       "nypl:locationsSlug": "lpa",
       "nypl:owner": {
@@ -49722,10 +50239,10 @@
       "skos:prefLabel": "Melrose Fiction"
     },
     {
-      "@id": "nyplLocation:pka",
+      "@id": "nyplLocation:sezzz",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:pk"
+        "@id": "nyplLocation:se"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -49736,9 +50253,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Parkchester Adult",
-      "skos:notation": "pka",
-      "skos:prefLabel": "Parkchester Adult"
+      "skos:altLabel": "Seward Park (error code)",
+      "skos:notation": "sezzz",
+      "skos:prefLabel": "Seward Park"
     },
     {
       "@id": "nyplLocation:mea0l",
@@ -49885,10 +50402,10 @@
       "skos:prefLabel": "Hamilton Grange Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:tmj01",
+      "@id": "nyplLocation:hbj0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tm"
+        "@id": "nyplLocation:hb"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -49899,9 +50416,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Tremont Children's Reference",
-      "skos:notation": "tmj01",
-      "skos:prefLabel": "Tremont Children's Reference"
+      "skos:altLabel": "High Bridge Children's Fiction",
+      "skos:notation": "hbj0f",
+      "skos:prefLabel": "High Bridge Children's Fiction"
     },
     {
       "@id": "nyplLocation:maln",
@@ -50401,25 +50918,6 @@
       "skos:prefLabel": "Roosevelt Island"
     },
     {
-      "@id": "nyplLocation:eaj0i",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Eastchester Children's Picture Book",
-      "skos:notation": "eaj0i",
-      "skos:prefLabel": "Eastchester Children's Picture Book"
-    },
-    {
       "@id": "nyplLocation:gca",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -50610,26 +51108,23 @@
       "skos:prefLabel": "Washington Heights"
     },
     {
-      "@id": "nyplLocation:myy0v",
+      "@id": "nyplLocation:tvj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
+        "@id": "nyplLocation:tv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1002"
-      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Performing Arts Circulating YA Non-Print Media",
-      "skos:notation": "myy0v",
-      "skos:prefLabel": "Performing Arts Circulating YA Non-Print Media"
+      "skos:altLabel": "Tottenville Children's Young Reader",
+      "skos:notation": "tvj0y",
+      "skos:prefLabel": "Tottenville Children's Young Reader"
     },
     {
       "@id": "nyplLocation:tvj0v",
@@ -50879,26 +51374,7 @@
       "skos:prefLabel": "Throg's Neck Children's World Languages"
     },
     {
-      "@id": "nyplLocation:epar",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ep"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Epiphany Adult Reference",
-      "skos:notation": "epar",
-      "skos:prefLabel": "Epiphany Adult Reference"
-    },
-    {
-      "@id": "nyplLocation:tgj0i",
+      "@id": "nyplLocation:tgj0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:tg"
@@ -50912,9 +51388,28 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Throg's Neck Children's Picture Book",
-      "skos:notation": "tgj0i",
-      "skos:prefLabel": "Throg's Neck Children's Picture Book"
+      "skos:altLabel": "Throg's Neck Children's Non-Fiction",
+      "skos:notation": "tgj0n",
+      "skos:prefLabel": "Throg's Neck Children's Non-Fiction"
+    },
+    {
+      "@id": "nyplLocation:kbj01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:kb"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Kingsbridge Children's Reference",
+      "skos:notation": "kbj01",
+      "skos:prefLabel": "Kingsbridge Children's Reference"
     },
     {
       "@id": "nyplLocation:tgj0h",
@@ -51085,8 +51580,8 @@
         "@value": "true"
       },
       "nypl:collectionType": [
-        "Branch",
-        "Research"
+        "Research",
+        "Branch"
       ],
       "nypl:deliverableTo": {
         "@id": "nyplLocation:myr"
@@ -51101,6 +51596,25 @@
       "skos:altLabel": "Performing Arts - Special Collections Desk - 3rd Fl",
       "skos:notation": "myrs",
       "skos:prefLabel": "Performing Arts - Special Collections Desk - 3rd Floor"
+    },
+    {
+      "@id": "nyplLocation:ota0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ot"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Ottendorfer Fiction",
+      "skos:notation": "ota0f",
+      "skos:prefLabel": "Ottendorfer Fiction"
     },
     {
       "@id": "nyplLocation:thy",
@@ -51273,34 +51787,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:malw"
-        },
-        {
           "@id": "nyplLocation:mala"
         },
         {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:mab"
         },
         {
           "@id": "nyplLocation:malc"
         },
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        },
+        {
+          "@id": "nyplLocation:malw"
         },
         {
           "@id": "nyplLocation:maln"
         },
         {
+          "@id": "nyplLocation:map"
+        },
+        {
           "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mai"
         }
       ],
       "nypl:owner": {
@@ -51312,7 +51826,7 @@
       },
       "skos:altLabel": "SASB M2 - Art and Architecture - Room 300",
       "skos:notation": "mab92",
-      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture - Room 300"
+      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture Room 300"
     },
     {
       "@id": "nyplLocation:tha",
@@ -51375,7 +51889,7 @@
       },
       "skos:altLabel": "SASB M2 - Art and Architecture (Restricted) - Room 300",
       "skos:notation": "mab99",
-      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture (Restricted) - Room 300"
+      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture (Restricted) Room 300"
     },
     {
       "@id": "nyplLocation:mab98",
@@ -51400,7 +51914,7 @@
       },
       "skos:altLabel": "SASB M2 - Art and Architecture - Room 300",
       "skos:notation": "mab98",
-      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture - Room 300"
+      "skos:prefLabel": "Schwarzman Building M2 - Art and Architecture Room 300"
     },
     {
       "@id": "nyplLocation:kbj0y",
@@ -51504,10 +52018,10 @@
       "skos:prefLabel": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
     },
     {
-      "@id": "nyplLocation:eay",
+      "@id": "nyplLocation:styr",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ea"
+        "@id": "nyplLocation:st"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -51518,9 +52032,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Eastchester Young Adult",
-      "skos:notation": "eay",
-      "skos:prefLabel": "Eastchester Young Adult"
+      "skos:altLabel": "Stapleton Young Adult Reference",
+      "skos:notation": "styr",
+      "skos:prefLabel": "Stapleton Young Adult Reference"
     },
     {
       "@id": "nyplLocation:kbj0l",
@@ -51656,10 +52170,10 @@
       "skos:prefLabel": "Kingsbridge Children's Fiction"
     },
     {
-      "@id": "nyplLocation:kbj0a",
+      "@id": "nyplLocation:eaj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:kb"
+        "@id": "nyplLocation:ea"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -51670,9 +52184,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Kingsbridge Children's Easy Book",
-      "skos:notation": "kbj0a",
-      "skos:prefLabel": "Kingsbridge Children's Easy Book"
+      "skos:altLabel": "Eastchester Children",
+      "skos:notation": "eaj",
+      "skos:prefLabel": "Eastchester Children"
     },
     {
       "@id": "nyplLocation:dhj0a",
@@ -51770,7 +52284,7 @@
       "skos:prefLabel": "St. Agnes Reference"
     },
     {
-      "@id": "nyplLocation:dhj0h",
+      "@id": "nyplLocation:dhar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
         "@id": "nyplLocation:dh"
@@ -51784,9 +52298,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Dongan Hills Children's Holiday Book",
-      "skos:notation": "dhj0h",
-      "skos:prefLabel": "Dongan Hills Children's Holiday Book"
+      "skos:altLabel": "Dongan Hills Adult Reference",
+      "skos:notation": "dhar",
+      "skos:prefLabel": "Dongan Hills Adult Reference"
     },
     {
       "@id": "nyplLocation:dhj0i",
@@ -51852,10 +52366,10 @@
       "skos:prefLabel": "Dongan Hills Children's World Languages"
     },
     {
-      "@id": "nyplLocation:dhj0n",
+      "@id": "nyplLocation:mna",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:mn"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -51866,9 +52380,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Dongan Hills Children's Non-Fiction",
-      "skos:notation": "dhj0n",
-      "skos:prefLabel": "Dongan Hills Children's Non-Fiction"
+      "skos:altLabel": "Mariner's Harbor Adult",
+      "skos:notation": "mna",
+      "skos:prefLabel": "Mariner's Harbor Adult"
     },
     {
       "@id": "nyplLocation:ewzzz",
@@ -51928,10 +52442,10 @@
       "skos:prefLabel": "Dongan Hills Children's Fairy Tale"
     },
     {
-      "@id": "nyplLocation:dhj0v",
+      "@id": "nyplLocation:eaar",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:ea"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -51942,9 +52456,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Dongan Hills Children's Non-Print Media",
-      "skos:notation": "dhj0v",
-      "skos:prefLabel": "Dongan Hills Children's Non-Print Media"
+      "skos:altLabel": "Eastchester Adult Reference",
+      "skos:notation": "eaar",
+      "skos:prefLabel": "Eastchester Adult Reference"
     },
     {
       "@id": "nyplLocation:mlyr",
@@ -52019,6 +52533,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -52031,29 +52546,54 @@
       "skos:prefLabel": "Science, Industry and Business Library (SIBL)"
     },
     {
-      "@id": "nyplLocation:yva",
+      "@id": "nyplLocation:mm2af",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:yv"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Yorkville Adult",
-      "skos:notation": "yva",
-      "skos:prefLabel": "Yorkville Adult"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2af",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
-      "@id": "nyplLocation:hgj01",
+      "@id": "nyplLocation:mm2al",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:hg"
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2al",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
+      "@id": "nyplLocation:ssar",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ss"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -52064,9 +52604,50 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Hamilton Grange Children's Reference",
-      "skos:notation": "hgj01",
-      "skos:prefLabel": "Hamilton Grange Children's Reference"
+      "skos:altLabel": "67th Street Adult Reference",
+      "skos:notation": "ssar",
+      "skos:prefLabel": "67th Street Adult Reference"
+    },
+    {
+      "@id": "nyplLocation:mm2an",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2an",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
+      "@id": "nyplLocation:tgy0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:tg"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Throg's Neck YA Non-Print Media",
+      "skos:notation": "tgy0v",
+      "skos:prefLabel": "Throg's Neck YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:hfar",
@@ -52195,34 +52776,34 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:malw"
+          "@id": "nyplLocation:map"
         },
         {
-          "@id": "nyplLocation:mab"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
-          "@id": "nyplLocation:maf"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:mal"
         },
         {
           "@id": "nyplLocation:mag"
         },
         {
-          "@id": "nyplLocation:map"
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mala"
         },
         {
           "@id": "nyplLocation:mai"
-        },
-        {
-          "@id": "nyplLocation:mal"
         }
       ],
       "nypl:owner": {
@@ -52363,18 +52944,6 @@
       "nypl:collectionType": "Research",
       "nypl:deliverableTo": [
         {
-          "@id": "nyplLocation:mal"
-        },
-        {
-          "@id": "nyplLocation:mag"
-        },
-        {
-          "@id": "nyplLocation:maln"
-        },
-        {
-          "@id": "nyplLocation:malc"
-        },
-        {
           "@id": "nyplLocation:myr"
         },
         {
@@ -52387,19 +52956,31 @@
           "@id": "nyplLocation:malw"
         },
         {
-          "@id": "nyplLocation:mala"
+          "@id": "nyplLocation:mai"
         },
         {
-          "@id": "nyplLocation:mab"
+          "@id": "nyplLocation:mag"
         },
         {
           "@id": "nyplLocation:maf"
         },
         {
-          "@id": "nyplLocation:mai"
+          "@id": "nyplLocation:sc"
         },
         {
-          "@id": "nyplLocation:sc"
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:malc"
         }
       ],
       "nypl:owner": {
@@ -52553,23 +53134,26 @@
       "skos:prefLabel": "Mid-Manhattan Non-Print Media First Floor"
     },
     {
-      "@id": "nyplLocation:mhj0y",
+      "@id": "nyplLocation:mm2a1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:mh"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Mott Haven Children's Young Reader",
-      "skos:notation": "mhj0y",
-      "skos:prefLabel": "Mott Haven Children's Young Reader"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm2a1",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:marr2",
@@ -52900,10 +53484,10 @@
       "skos:prefLabel": "Seward Park YA Fiction"
     },
     {
-      "@id": "nyplLocation:tmj0h",
+      "@id": "nyplLocation:sv",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:tm"
+        "@id": "nyplLocation:sv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -52914,47 +53498,31 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Tremont Children's Holiday Book",
-      "skos:notation": "tmj0h",
-      "skos:prefLabel": "Tremont Children's Holiday Book"
+      "skos:altLabel": "Soundview",
+      "skos:notation": "sv",
+      "skos:prefLabel": "Soundview"
     },
     {
-      "@id": "nyplLocation:chyr",
+      "@id": "nyplLocation:mm4av",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ch"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Chatham Square Young Adult Reference",
-      "skos:notation": "chyr",
-      "skos:prefLabel": "Chatham Square Young Adult Reference"
-    },
-    {
-      "@id": "nyplLocation:sey0n",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Seward Park YA Non-Fiction",
-      "skos:notation": "sey0n",
-      "skos:prefLabel": "Seward Park YA Non-Fiction"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4av",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:sey0l",
@@ -52976,42 +53544,70 @@
       "skos:prefLabel": "Seward Park YA World Languages"
     },
     {
-      "@id": "nyplLocation:sey0v",
+      "@id": "nyplLocation:mm4an",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:se"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Seward Park YA Non-Print Media",
-      "skos:notation": "sey0v",
-      "skos:prefLabel": "Seward Park YA Non-Print Media"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4an",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
-      "@id": "nyplLocation:ssar",
+      "@id": "nyplLocation:mm4al",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ss"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "67th Street Adult Reference",
-      "skos:notation": "ssar",
-      "skos:prefLabel": "67th Street Adult Reference"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4al",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
+    },
+    {
+      "@id": "nyplLocation:mm4af",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:mm"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4af",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:nbj0f",
@@ -53090,42 +53686,26 @@
       "skos:prefLabel": "Bloomingdale YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:jpj0y",
+      "@id": "nyplLocation:mm4a1",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:jp"
+        "@id": "nyplLocation:mm"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
       "nypl:collectionType": "Branch",
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1500"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Jerome Park Children's Young Reader",
-      "skos:notation": "jpj0y",
-      "skos:prefLabel": "Jerome Park Children's Young Reader"
-    },
-    {
-      "@id": "nyplLocation:tsjr",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:ts"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Tompkins Square Children's Reference",
-      "skos:notation": "tsjr",
-      "skos:prefLabel": "Tompkins Square Children's Reference"
+      "skos:altLabel": "Mid-Manhattan Library at 42nd Street",
+      "skos:notation": "mm4a1",
+      "skos:prefLabel": "Mid-Manhattan Library at 42nd Street"
     },
     {
       "@id": "nyplLocation:sey01",
@@ -53381,6 +53961,25 @@
       "skos:prefLabel": "Grand Central Children's Fiction"
     },
     {
+      "@id": "nyplLocation:wly01",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:wl"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Woodlawn Heights YA Reference",
+      "skos:notation": "wly01",
+      "skos:prefLabel": "Woodlawn Heights YA Reference"
+    },
+    {
       "@id": "nyplLocation:gcj0a",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -53400,10 +53999,10 @@
       "skos:prefLabel": "Grand Central Children's Easy Book"
     },
     {
-      "@id": "nyplLocation:gcj0n",
+      "@id": "nyplLocation:pk",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:gc"
+        "@id": "nyplLocation:pk"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53414,9 +54013,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Grand Central Children's Non-Fiction",
-      "skos:notation": "gcj0n",
-      "skos:prefLabel": "Grand Central Children's Non-Fiction"
+      "skos:altLabel": "Parkchester",
+      "skos:notation": "pk",
+      "skos:prefLabel": "Parkchester"
     },
     {
       "@id": "nyplLocation:fea03",
@@ -53457,10 +54056,10 @@
       "skos:prefLabel": "Grand Central Children's World Languages"
     },
     {
-      "@id": "nyplLocation:fea01",
+      "@id": "nyplLocation:jpj0y",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:fe"
+        "@id": "nyplLocation:jp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53471,9 +54070,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "58th Street Reference",
-      "skos:notation": "fea01",
-      "skos:prefLabel": "58th Street Reference"
+      "skos:altLabel": "Jerome Park Children's Young Reader",
+      "skos:notation": "jpj0y",
+      "skos:prefLabel": "Jerome Park Children's Young Reader"
     },
     {
       "@id": "nyplLocation:gcj0h",
@@ -53666,10 +54265,10 @@
       "skos:prefLabel": "Kips Bay YA World Languages"
     },
     {
-      "@id": "nyplLocation:ftzzz",
+      "@id": "nyplLocation:kpy0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ft"
+        "@id": "nyplLocation:kp"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53680,28 +54279,28 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "53rd Street (error code)",
-      "skos:notation": "ftzzz",
-      "skos:prefLabel": "53rd Street"
+      "skos:altLabel": "Kips Bay YA Non-Fiction",
+      "skos:notation": "kpy0n",
+      "skos:prefLabel": "Kips Bay YA Non-Fiction"
     },
     {
-      "@id": "nyplLocation:nsyr",
+      "@id": "nyplLocation:lsbx2",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ns"
+        "@id": "nyplLocation:ls"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "96th Street Young Adult Reference",
-      "skos:notation": "nsyr",
-      "skos:prefLabel": "96th Street Young Adult Reference"
+      "skos:altLabel": "Library Services Center - Cataloging - Research Storage",
+      "skos:notation": "lsbx2",
+      "skos:prefLabel": "Library Services Center - Cataloging - Research Storage"
     },
     {
       "@id": "nyplLocation:kpy0f",
@@ -53802,10 +54401,10 @@
       "skos:prefLabel": "Battery Park World Languages"
     },
     {
-      "@id": "nyplLocation:dhy0l",
+      "@id": "nyplLocation:bta0n",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:dh"
+        "@id": "nyplLocation:bt"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53816,9 +54415,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Dongan Hills YA World Languages",
-      "skos:notation": "dhy0l",
-      "skos:prefLabel": "Dongan Hills YA World Languages"
+      "skos:altLabel": "Battery Park Non-Fiction",
+      "skos:notation": "bta0n",
+      "skos:prefLabel": "Battery Park Non-Fiction"
     },
     {
       "@id": "nyplLocation:bcj0t",
@@ -53859,10 +54458,10 @@
       "skos:prefLabel": "Dongan Hills YA Fiction"
     },
     {
-      "@id": "nyplLocation:cpa03",
+      "@id": "nyplLocation:bta0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:cp"
+        "@id": "nyplLocation:bt"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53873,9 +54472,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Clason's Point Closed Shelf Reference",
-      "skos:notation": "cpa03",
-      "skos:prefLabel": "Clason's Point Closed Shelf Reference"
+      "skos:altLabel": "Battery Park Fiction",
+      "skos:notation": "bta0f",
+      "skos:prefLabel": "Battery Park Fiction"
     },
     {
       "@id": "nyplLocation:dhy0v",
@@ -53973,10 +54572,10 @@
       "skos:prefLabel": "Eastchester Children's Holiday Book"
     },
     {
-      "@id": "nyplLocation:sbyr",
+      "@id": "nyplLocation:csy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:sb"
+        "@id": "nyplLocation:cs"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -53987,9 +54586,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "South Beach Young Adult Reference",
-      "skos:notation": "sbyr",
-      "skos:prefLabel": "South Beach Young Adult Reference"
+      "skos:altLabel": "Columbus YA Fiction",
+      "skos:notation": "csy0f",
+      "skos:prefLabel": "Columbus YA Fiction"
     },
     {
       "@id": "nyplLocation:eaj0f",
@@ -54334,10 +54933,10 @@
       "skos:prefLabel": "Clason's Point World Languages"
     },
     {
-      "@id": "nyplLocation:bl",
+      "@id": "nyplLocation:gdj0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:bl"
+        "@id": "nyplLocation:gd"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -54348,9 +54947,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Bloomingdale",
-      "skos:notation": "bl",
-      "skos:prefLabel": "Bloomingdale"
+      "skos:altLabel": "Grand Concourse Children's Non-Print Media",
+      "skos:notation": "gdj0v",
+      "skos:prefLabel": "Grand Concourse Children's Non-Print Media"
     },
     {
       "@id": "nyplLocation:cpa0n",
@@ -54448,10 +55047,10 @@
       "skos:prefLabel": "Baychester"
     },
     {
-      "@id": "nyplLocation:wla0v",
+      "@id": "nyplLocation:tva03",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
+        "@id": "nyplLocation:tv"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -54462,9 +55061,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Woodlawn Heights Non-Print Media",
-      "skos:notation": "wla0v",
-      "skos:prefLabel": "Woodlawn Heights Non-Print Media"
+      "skos:altLabel": "Tottenville Closed Shelf Reference",
+      "skos:notation": "tva03",
+      "skos:prefLabel": "Tottenville Closed Shelf Reference"
     },
     {
       "@id": "nyplLocation:bc",
@@ -54541,6 +55140,25 @@
       "skos:altLabel": "Bloomingdale YA Reference",
       "skos:notation": "bly01",
       "skos:prefLabel": "Bloomingdale YA Reference"
+    },
+    {
+      "@id": "nyplLocation:bey0v",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:be"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Belmont YA Non-Print Media",
+      "skos:notation": "bey0v",
+      "skos:prefLabel": "Belmont YA Non-Print Media"
     },
     {
       "@id": "nyplLocation:eaj01",
@@ -54791,28 +55409,6 @@
       "skos:prefLabel": "Roosevelt Island Children"
     },
     {
-      "@id": "nyplLocation:myav3",
-      "@type": "nypl:Location",
-      "dcterms:isPartOf": {
-        "@id": "nyplLocation:my"
-      },
-      "nypl:allowSierraHold": {
-        "@type": "XSD:boolean",
-        "@value": "true"
-      },
-      "nypl:collectionType": "Branch",
-      "nypl:owner": {
-        "@id": "http://data.nypl.org/orgs/1002"
-      },
-      "nypl:requestable": {
-        "@type": "XSD:boolean",
-        "@value": "false"
-      },
-      "skos:altLabel": "Performing Arts Closed Shelf Reference Recorded Media",
-      "skos:notation": "myav3",
-      "skos:prefLabel": "Performing Arts Closed Shelf Reference Recorded Media"
-    },
-    {
       "@id": "nyplLocation:hsj",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -54841,6 +55437,7 @@
         "@type": "XSD:boolean",
         "@value": "true"
       },
+      "nypl:collectionType": "Branch",
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1125"
       },
@@ -54970,6 +55567,60 @@
       "skos:prefLabel": "Belmont Young Adult"
     },
     {
+      "@id": "nyplLocation:maf82",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:ma"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": [
+        {
+          "@id": "nyplLocation:malw"
+        },
+        {
+          "@id": "nyplLocation:malc"
+        },
+        {
+          "@id": "nyplLocation:mal"
+        },
+        {
+          "@id": "nyplLocation:mai"
+        },
+        {
+          "@id": "nyplLocation:maln"
+        },
+        {
+          "@id": "nyplLocation:mala"
+        },
+        {
+          "@id": "nyplLocation:map"
+        },
+        {
+          "@id": "nyplLocation:maf"
+        },
+        {
+          "@id": "nyplLocation:mab"
+        },
+        {
+          "@id": "nyplLocation:mag"
+        }
+      ],
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1103"
+      },
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "SASB M1 - Dorot Jewish Division Rm 111",
+      "skos:notation": "maf82",
+      "skos:prefLabel": "Schwarzman Building - Dorot Jewish Division Room 111"
+    },
+    {
       "@id": "nyplLocation:cty0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -54999,8 +55650,8 @@
         "@value": "true"
       },
       "nypl:collectionType": [
-        "Branch",
-        "Research"
+        "Research",
+        "Branch"
       ],
       "nypl:owner": {
         "@id": "http://data.nypl.org/orgs/1002"
@@ -55055,10 +55706,10 @@
       "skos:prefLabel": "Mid-Manhattan Non-Fiction Third Floor"
     },
     {
-      "@id": "nyplLocation:epy01",
+      "@id": "nyplLocation:hfy0f",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:ep"
+        "@id": "nyplLocation:hf"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
@@ -55069,9 +55720,9 @@
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Epiphany YA Reference",
-      "skos:notation": "epy01",
-      "skos:prefLabel": "Epiphany YA Reference"
+      "skos:altLabel": "Hamilton Fish Park YA Fiction",
+      "skos:notation": "hfy0f",
+      "skos:prefLabel": "Hamilton Fish Park YA Fiction"
     },
     {
       "@id": "nyplLocation:bea",
@@ -56473,6 +57124,25 @@
       "skos:prefLabel": "115th Street Reference"
     },
     {
+      "@id": "nyplLocation:rty0n",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:rt"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Richmondtown YA Non-Fiction",
+      "skos:notation": "rty0n",
+      "skos:prefLabel": "Richmondtown YA Non-Fiction"
+    },
+    {
       "@id": "nyplLocation:lma0v",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -57067,6 +57737,25 @@
       "skos:prefLabel": "New Amsterdam Closed Shelf Reference"
     },
     {
+      "@id": "nyplLocation:tha0f",
+      "@type": "nypl:Location",
+      "dcterms:isPartOf": {
+        "@id": "nyplLocation:th"
+      },
+      "nypl:allowSierraHold": {
+        "@type": "XSD:boolean",
+        "@value": "true"
+      },
+      "nypl:collectionType": "Branch",
+      "nypl:requestable": {
+        "@type": "XSD:boolean",
+        "@value": "false"
+      },
+      "skos:altLabel": "Todt Hill-Westerleigh Fiction",
+      "skos:notation": "tha0f",
+      "skos:prefLabel": "Todt Hill-Westerleigh Fiction"
+    },
+    {
       "@id": "nyplLocation:fx",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
@@ -57124,23 +57813,29 @@
       "skos:prefLabel": "Soundview YA Reference"
     },
     {
-      "@id": "nyplLocation:wla03",
+      "@id": "nyplLocation:mym42",
       "@type": "nypl:Location",
       "dcterms:isPartOf": {
-        "@id": "nyplLocation:wl"
+        "@id": "nyplLocation:my"
       },
       "nypl:allowSierraHold": {
         "@type": "XSD:boolean",
         "@value": "true"
       },
-      "nypl:collectionType": "Branch",
+      "nypl:collectionType": "Research",
+      "nypl:deliverableTo": {
+        "@id": "nyplLocation:myr"
+      },
+      "nypl:owner": {
+        "@id": "http://data.nypl.org/orgs/1002"
+      },
       "nypl:requestable": {
         "@type": "XSD:boolean",
         "@value": "false"
       },
-      "skos:altLabel": "Woodlawn Heights Closed Shelf Reference",
-      "skos:notation": "wla03",
-      "skos:prefLabel": "Woodlawn Heights Closed Shelf Reference"
+      "skos:altLabel": "OFFSITE Rose - Request in advance for use at Performing Arts",
+      "skos:notation": "mym42",
+      "skos:prefLabel": "Offsite Rose - Performing Arts"
     }
   ]
 }


### PR DESCRIPTION
This fixes an issue where this by-sierra-location factory was exposing
`collectionType`, but using the data found in `locationType` (a
deprecated nypl-core location property). In the absense of that
data, our factory was falling back on a sensible default of
['Branch']. This PR wires up the factory to correctly use the actual
data in the nypl-core `collectionType` property so that integrators can
act on whether or not a location's collection has "Research" materials.
Also adds some tests.

Also adds updated locations.json fixture with latest from nypl-core.

Also removes `--globals expect` arg from `test` script in package.json because it's redundant.