### PR TITLE
update factory with collectionAccessType

### DIFF
--- a/lib/by_sierra_location_factory.js
+++ b/lib/by_sierra_location_factory.js
@@ -61,7 +61,8 @@ class BySierraLocationFactory extends FactoryBase {
         sierraDeliveryLocations,
         requestable: jsonldParseUtils._conditional_boolean(location['nypl:requestable']),
         deliveryLocationTypes: jsonldParseUtils.forcetoFlatArray(location['nypl:deliveryLocationType']),
-        deliverableToResolution
+        deliverableToResolution,
+        collectionAccessType: location['nypl:collectionAccessType']
       }
       return _returnedMap
     }, {})

--- a/test/by-sierra-location.test.js
+++ b/test/by-sierra-location.test.js
@@ -34,6 +34,14 @@ describe('by-sierra-location', function () {
       })
     })
 
+    it('has a collectionAccessType property', function () {
+      Object.keys(this.bySierraLocation)
+        .forEach((code) => {
+          expect('collectionAccessType' in this.bySierraLocation[code])
+            .to.eql(true)
+        })
+    })
+
     it('has a deliverableToResolution property', function () {
       Object.keys(this.bySierraLocation)
         .forEach((code) => {


### PR DESCRIPTION
Update `BySierraLocationsFactory` with new `collectionAccessType` values.

In case you want to verify this locally, I mis-tagged the NYPL core update prerelease as v2.22a instead v2.23a.
